### PR TITLE
refactor: minor cleanups from PR 181 comparison

### DIFF
--- a/pyvizio/api/item.py
+++ b/pyvizio/api/item.py
@@ -157,7 +157,7 @@ class ItemCommandBase(CommandBase):
 
 
 class AltItemInfoCommandBase(ItemInfoCommandBase):
-    """Command to get individual item setting."""
+    """Command to get individual item setting from alternate endpoint."""
 
     def __init__(
         self,
@@ -166,7 +166,7 @@ class AltItemInfoCommandBase(ItemInfoCommandBase):
         item_name: str,
         default_return: int | str | None = None,
     ) -> None:
-        """Initialize command to get individual item setting."""
+        """Initialize command to get individual item setting from alternate endpoint."""
         super(ItemInfoCommandBase, self).__init__(ENDPOINT[device_type][endpoint_name])
         self.item_name = item_name.upper()
         self.default_return = default_return

--- a/pyvizio/cli.py
+++ b/pyvizio/cli.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
 
 import click
 from tabulate import tabulate
@@ -89,7 +88,7 @@ def cli(ctx, ip: str, auth: str, device_type: str) -> None:
     show_envvar=True,
 )
 def discover(include_device_type: bool, timeout: int) -> None:
-    devices: list[Any] = VizioAsync.discovery_zeroconf(timeout)
+    devices: list = VizioAsync.discovery_zeroconf(timeout)
 
     data = []
 
@@ -240,10 +239,7 @@ async def get_charging_status(vizio: VizioAsync) -> None:
 @pass_vizio
 async def get_battery_level(vizio: VizioAsync) -> None:
     level = await vizio.get_battery_level()
-    if 0 == level:
-        _LOGGER.info("Current battery level: %s", "Charging")
-    else:
-        _LOGGER.info("Current battery level: %s", level)
+    _LOGGER.info("Current battery level: %s", "Charging" if level == 0 else level)
 
 
 @cli.command()
@@ -431,11 +427,11 @@ async def get_all_audio_settings(vizio: VizioAsync) -> None:
 async def get_all_audio_settings_options(vizio: VizioAsync) -> None:
     audio_settings_options = await vizio.get_all_audio_settings_options()
     if audio_settings_options:
-        options: list[list[Any]] = []
+        options = []
         for k, v in audio_settings_options.items():
             if isinstance(v, dict):
                 options.append([k, v.get("default"), v["min"], v["max"], None])
-            elif isinstance(v, list):
+            else:
                 options.append([k, None, None, None, ", ".join(v)])
         table = tabulate(options, headers=["Name", "Default", "Min", "Max", "Choices"])
         _LOGGER.info("\n%s", table)
@@ -524,11 +520,11 @@ async def get_all_settings(vizio: VizioAsync, setting_type: str) -> None:
 async def get_all_settings_options(vizio: VizioAsync, setting_type: str) -> None:
     settings_options = await vizio.get_all_settings_options(setting_type)
     if settings_options:
-        options: list[list[Any]] = []
+        options = []
         for k, v in settings_options.items():
             if isinstance(v, dict):
                 options.append([k, v.get("default"), v["min"], v["max"], None])
-            elif isinstance(v, list):
+            else:
                 options.append([k, None, None, None, ", ".join(v)])
         table = tabulate(options, headers=["Name", "Default", "Min", "Max", "Choices"])
         _LOGGER.info("\n%s", table)


### PR DESCRIPTION
## Summary
- Clarify `AltItemInfoCommandBase` docstrings to mention "from alternate endpoint"
- Simplify battery level logging in CLI (single log call)
- Remove unnecessary `from typing import Any` and type annotations in CLI
- Simplify `elif isinstance(v, list)` → `else` in settings options display

Picked up from comparing PR #181 against current master after PRs #188, #191, #192 landed.

## Test plan
- [x] `uv run pytest tests/` — 219 passed
- [x] `uv run --extra dev mypy --warn-unused-ignores pyvizio/` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)