### PR TITLE
fix(protocol): real-device fixes for VHD24M-0810 fw 3.720.9.1-1 + /state_extended endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,4 @@ ENV/
 
 # Claude Code
 .claude/
+.serena/

--- a/pyvizio/__init__.py
+++ b/pyvizio/__init__.py
@@ -33,6 +33,7 @@ from pyvizio.api.item import (
     AltItemInfoCommandBase,
     GetDeviceInfoCommand,
     GetModelNameCommand,
+    GetTvInformationCommand,
     ItemInfoCommandBase,
 )
 from pyvizio.api.pair import (
@@ -53,6 +54,7 @@ from pyvizio.api.settings import (
     GetSettingOptionsCommand,
     GetSettingOptionsXListCommand,
 )
+from pyvizio.api.state_extended import GetStateExtendedCommand, StateExtended
 from pyvizio.const import (
     APP_HOME,
     APPS,
@@ -69,16 +71,63 @@ from pyvizio.discovery.ssdp import SSDPDevice, discover as discover_ssdp
 from pyvizio.discovery.zeroconf import ZeroconfDevice, discover as discover_zc
 from pyvizio.errors import (
     VizioAuthError,
+    VizioBusyError as VizioBusyError,
     VizioConnectionError as VizioConnectionError,
     VizioError as VizioError,
+    VizioInvalidInputError,
     VizioInvalidParameterError as VizioInvalidParameterError,
+    VizioNotFoundError as VizioNotFoundError,
     VizioResponseError as VizioResponseError,
+    VizioUnsupportedError as VizioUnsupportedError,
 )
-from pyvizio.helpers import async_to_sync, open_port
+from pyvizio.helpers import async_to_sync, dict_get_case_insensitive, open_port
 from pyvizio.util import gen_apps_list_from_url
 from pyvizio.version import __version__ as __version__
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _resolve_input_cname(name: str, inputs: list[InputItem]) -> str:
+    """Resolve a user-supplied input identifier to its canonical cname.
+
+    The device's PUT body for ``current_input`` carries the lowercase
+    **cname** (e.g. ``"hdmi2"``), not the display name (``"HDMI-2"``)
+    or the meta_name (``"Mac"``). Verified live on VHD24M-0810 fw
+    3.720.9.1-1: PUT VALUE=``HDMI-2`` → FAILURE; PUT VALUE=``Mac`` →
+    HASHVAL_ERROR; PUT VALUE=``hdmi2`` → SUCCESS.
+
+    Resolution order, all case-insensitive:
+
+    1. Exact ``cname`` match (most specific).
+    2. Exact ``meta_name`` match (handles CAST/SMARTCAST and user
+       renames).
+    3. Exact display ``name`` match (label fallback).
+
+    Raises :class:`VizioInvalidInputError` when no input matches, or
+    when a label is ambiguous within the same resolution tier (user
+    renamed two HDMIs to the same label).
+    """
+    target = name.lower()
+    candidates_by_tier = {
+        "cname": [i for i in inputs if (i.c_name or "").lower() == target],
+        "meta_name": [i for i in inputs if (i.meta_name or "").lower() == target],
+        "name": [i for i in inputs if (i.name or "").lower() == target],
+    }
+    for tier, hits in candidates_by_tier.items():
+        if len(hits) == 1:
+            return (hits[0].c_name or "").lower()
+        if len(hits) > 1:
+            raise VizioInvalidInputError(
+                f"input {name!r} matches multiple inputs by {tier} "
+                f"({[h.c_name for h in hits]}); rename one to disambiguate"
+            )
+
+    valid = sorted(
+        {(i.c_name or "").lower() for i in inputs}
+        | {i.name or "" for i in inputs}
+        | {i.meta_name or "" for i in inputs if i.meta_name}
+    )
+    raise VizioInvalidInputError(f"input {name!r} not found. Valid: {valid}")
 
 
 class VizioAsync:
@@ -116,6 +165,14 @@ class VizioAsync:
         self._semaphore: asyncio.Semaphore | None = None
         self._latest_apps: list[dict[str, Any]] | None = None
         self._latest_apps_last_updated: datetime | None = None
+        # Identity (esn / serial_number / firmware / version) is
+        # immutable for a device's lifetime, so the aggregate fetch is
+        # cached on the instance after the first attempt. ``_loaded``
+        # captures both success (mapping) and failure (None) — without
+        # it, three identity calls on a device that doesn't expose the
+        # aggregate would each pay the round-trip + URI_NOT_FOUND.
+        self._cached_identity: dict[str, str] | None = None
+        self._cached_identity_loaded: bool = False
 
     def __repr__(self) -> str:
         return f"{type(self).__name__}({self.__dict__})"
@@ -168,9 +225,16 @@ class VizioAsync:
             )
 
     async def __invoke_api_auth(
-        self, cmd: CommandBase, log_api_exception: bool = True
+        self,
+        cmd: CommandBase,
+        log_api_exception: bool = True,
+        skip_envelope: bool = False,
     ) -> Any:
-        """Asynchronously call SmartCast API with auth token."""
+        """Asynchronously call SmartCast API with auth token.
+
+        ``skip_envelope=True`` is for endpoints with non-standard
+        response shapes (currently only ``/state_extended``).
+        """
         async with self._get_semaphore():
             if ":" not in self.ip:
                 await self.__add_port()
@@ -183,6 +247,7 @@ class VizioAsync:
                 custom_timeout=self._timeout,
                 log_api_exception=log_api_exception,
                 session=self._session,
+                skip_envelope=skip_envelope,
             )
 
     async def __invoke_api_may_need_auth(
@@ -233,6 +298,40 @@ class VizioAsync:
         """Asynchronously call key press API with list of same key repeated multiple times."""
         key_codes = [key_code for _ in range(num)]
         return await self.__remote(key_codes, log_api_exception=log_api_exception)
+
+    async def __get_identity_aggregate(
+        self, log_api_exception: bool = True
+    ) -> dict[str, str] | None:
+        """Asynchronously fetch the aggregate ``tv_information`` envelope.
+
+        Result is cached on the instance — identity is immutable for a
+        device's lifetime. Three identity calls (esn + serial_number +
+        version) now make one HTTP round trip instead of three when the
+        aggregate is exposed.
+
+        Returns a ``cname → value`` mapping, or ``None`` when the
+        aggregate isn't exposed at either path. Returning ``None`` is
+        cached too, so older firmware that requires per-field paths
+        doesn't re-pay the URI_NOT_FOUND round trip on every call.
+        """
+        if self._cached_identity_loaded:
+            return self._cached_identity
+        self._cached_identity_loaded = True
+        for endpoint_key in ("TV_INFORMATION", "_ALT_TV_INFORMATION"):
+            if endpoint_key not in self._device_config.endpoints:
+                continue
+            try:
+                mapping = await self.__invoke_api_may_need_auth(
+                    GetTvInformationCommand(self.device_type, endpoint_key),
+                    log_api_exception=log_api_exception,
+                )
+            except VizioError:
+                continue
+            if mapping:
+                self._cached_identity = mapping
+                return mapping
+        self._cached_identity = None
+        return None
 
     async def __get_cached_apps_list(self) -> list[dict[str, Any]]:
         if (
@@ -315,10 +414,21 @@ class VizioAsync:
         ).get_serial_number(log_api_exception=False)
 
     async def can_connect_with_auth_check(self) -> bool:
-        """Asynchronously return whether or not device API can be connected to with valid authorization."""
-        return bool(
-            await VizioAsync.get_all_audio_settings(self, log_api_exception=False)
-        )
+        """Asynchronously return whether or not device API can be connected to with valid authorization.
+
+        Probe-style helper — must always return a bool, never propagate.
+        With the new HTTP 401/403 → :class:`VizioAuthError` mapping
+        (re-pair invalidation surfaces here), the underlying call now
+        raises that exception instead of being suppressed by
+        ``log_api_exception=False`` — the propagation is load-bearing
+        for non-probe callers, but here we want the bool contract.
+        """
+        try:
+            return bool(
+                await VizioAsync.get_all_audio_settings(self, log_api_exception=False)
+            )
+        except VizioAuthError:
+            return False
 
     async def can_connect_no_auth_check(self) -> bool:
         """Asynchronously return whether or not device API can be connected to regardless of authorization."""
@@ -329,7 +439,15 @@ class VizioAsync:
         )
 
     async def get_esn(self, log_api_exception: bool = True) -> str | None:
-        """Asynchronously get device's ESN (electronic serial number?)."""
+        """Asynchronously get device's ESN (electronic serial number?).
+
+        Prefers the aggregate ``TV_INFORMATION`` endpoint; falls back
+        to per-field ``ESN`` / ``_ALT_ESN`` paths for older firmware.
+        """
+        agg = await self.__get_identity_aggregate(log_api_exception=log_api_exception)
+        if agg and agg.get("esn"):
+            return agg["esn"]
+
         item = await self.__invoke_api_may_need_auth(
             ItemInfoCommandBase(self.device_type, "ESN"),
             log_api_exception=log_api_exception,
@@ -344,7 +462,15 @@ class VizioAsync:
         return None
 
     async def get_serial_number(self, log_api_exception: bool = True) -> str | None:
-        """Asynchronously get device's serial number."""
+        """Asynchronously get device's serial number.
+
+        Prefers the aggregate ``TV_INFORMATION`` endpoint; falls back
+        to per-field paths for older firmware.
+        """
+        agg = await self.__get_identity_aggregate(log_api_exception=log_api_exception)
+        if agg and agg.get("serial_number"):
+            return agg["serial_number"]
+
         item = await self.__invoke_api(
             ItemInfoCommandBase(self.device_type, "SERIAL_NUMBER"),
             log_api_exception=log_api_exception,
@@ -361,7 +487,18 @@ class VizioAsync:
         return None
 
     async def get_version(self, log_api_exception: bool = True) -> str | None:
-        """Asynchronously get SmartCast software version on device."""
+        """Asynchronously get SmartCast software version on device.
+
+        Prefers the aggregate ``TV_INFORMATION`` endpoint, where the
+        version is exposed under cname ``"firmware"`` (modern firmware)
+        or ``"version"`` (older). Falls back to per-field paths.
+        """
+        agg = await self.__get_identity_aggregate(log_api_exception=log_api_exception)
+        if agg:
+            for cname in ("version", "firmware"):
+                if agg.get(cname):
+                    return agg[cname]
+
         item = await self.__invoke_api(
             ItemInfoCommandBase(self.device_type, "VERSION"),
             log_api_exception=log_api_exception,
@@ -440,20 +577,122 @@ class VizioAsync:
         )
 
     async def set_input(self, name: str, log_api_exception: bool = True) -> bool | None:
-        """Asynchronously switch active input to named input."""
+        """Asynchronously switch active input to named input.
+
+        ``name`` accepts any of the input's three identifier forms,
+        case-insensitively: cname (``"hdmi2"``), display name
+        (``"HDMI-2"``), or meta_name (``"Mac"`` / ``"SMARTCAST"``).
+        Verified live on VHD24M-0810 fw 3.720.9.1-1: only the
+        lowercase cname succeeds in the PUT body — display name
+        returns FAILURE, meta_name returns HASHVAL_ERROR. This method
+        translates any of the three forms before sending.
+
+        Short-circuits when already on the target input — the device
+        explicitly rejects "switch to current input" with FAILURE.
+        """
         curr_input_item = await self.__invoke_api_may_need_auth(
             GetCurrentInputCommand(self.device_type),
             log_api_exception=log_api_exception,
         )
-
         if not curr_input_item:
             _LOGGER.error("Couldn't detect current input")
             return None
 
-        return await self.__invoke_api_may_need_auth(
-            ChangeInputCommand(self.device_type, curr_input_item.id, name),
+        inputs = await self.__invoke_api_may_need_auth(
+            GetInputsListCommand(self.device_type),
             log_api_exception=log_api_exception,
         )
+        if not inputs:
+            _LOGGER.error("Couldn't fetch inputs list")
+            return None
+
+        try:
+            target_cname = _resolve_input_cname(name, inputs)
+        except VizioInvalidInputError as err:
+            if log_api_exception:
+                _LOGGER.error("%s", err)
+            return None
+
+        # Short-circuit when already on target. ``current_input.value``
+        # is inconsistent across input types (display name for HDMI,
+        # meta_name for CAST) so check against any of the three forms.
+        target_input = next(
+            (i for i in inputs if (i.c_name or "").lower() == target_cname),
+            None,
+        )
+        if target_input and isinstance(curr_input_item.value, str):
+            candidates = {
+                target_cname,
+                (target_input.name or "").lower(),
+                (target_input.meta_name or "").lower(),
+            }
+            if curr_input_item.value.lower() in candidates:
+                return True
+
+        return await self.__invoke_api_may_need_auth(
+            ChangeInputCommand(self.device_type, curr_input_item.id, target_cname),
+            log_api_exception=log_api_exception,
+        )
+
+    async def get_state_extended(
+        self, log_api_exception: bool = True
+    ) -> StateExtended | None:
+        """Asynchronously fetch aggregate device state in one HTTP round trip.
+
+        Returns power, current input, current app, screen mode, and
+        media state — meaningfully cheaper than five individual GETs
+        for HA-style polling integrations. Capability is advertised
+        under ``deviceinfo.scpl_capabilities.state_extended``; older
+        firmware that doesn't expose the endpoint surfaces as ``None``
+        (the underlying :class:`VizioNotFoundError` is suppressed by
+        the standard ``log_api_exception`` path).
+
+        The on-the-wire envelope is **distinct** from the regular
+        SCPL response shape — flat top-level keys, no
+        ``STATUS``/``ITEMS`` — so we invoke with
+        ``skip_envelope=True`` and detect URI_NOT_FOUND-shaped
+        fall-through manually.
+
+        Returns ``None`` for device types that don't expose the
+        endpoint (speakers, Crave) — they have no ``STATE_EXTENDED``
+        in :data:`DEVICE_CONFIGS`.
+        """
+        if "STATE_EXTENDED" not in self._device_config.endpoints:
+            if log_api_exception:
+                _LOGGER.debug("%r doesn't expose /state_extended", self.device_type)
+            return None
+
+        try:
+            result = await self.__invoke_api_auth(
+                GetStateExtendedCommand(self.device_type),
+                log_api_exception=log_api_exception,
+                skip_envelope=True,
+            )
+        except VizioAuthError:
+            raise
+        except VizioError as err:
+            if log_api_exception:
+                _LOGGER.error("Failed to fetch /state_extended: %s", err)
+            return None
+
+        if result is None:
+            return None
+
+        # ``skip_envelope`` bypassed standard validation, so older
+        # firmware that returns the SCPL envelope ``{"STATUS":
+        # {"RESULT": "URI_NOT_FOUND", ...}}`` here would otherwise
+        # produce a default-filled StateExtended that callers can't
+        # distinguish from a real all-default state. Detect that
+        # shape manually and treat as "endpoint unsupported".
+        raw = result.raw if isinstance(result, StateExtended) else {}
+        status_obj = dict_get_case_insensitive(raw, "status")
+        if isinstance(status_obj, dict):
+            res = dict_get_case_insensitive(status_obj, "result")
+            if isinstance(res, str) and res.lower() == "uri_not_found":
+                if log_api_exception:
+                    _LOGGER.debug("/state_extended not exposed by this firmware")
+                return None
+        return result
 
     async def get_power_state(self, log_api_exception: bool = True) -> bool | None:
         """Asynchronously get device's current power state."""
@@ -524,19 +763,22 @@ class VizioAsync:
         return int(volume) if volume else None
 
     async def is_muted(self, log_api_exception: bool = True) -> bool | None:
-        """Asynchronously determine whether or not device is muted."""
-        # If None is returned lower() will fail, if not we can do a simple boolean check
+        """Asynchronously determine whether or not device is muted.
+
+        Returns ``None`` when the underlying mute setting can't be
+        read (transport / device error). The state-aware
+        :meth:`mute_on` / :meth:`mute_off` rely on the ``None`` signal
+        to avoid blindly toggling on an unknown state.
+        """
         try:
-            return (
-                str(
-                    await VizioAsync.get_audio_setting(
-                        self, "mute", log_api_exception=log_api_exception
-                    )
-                ).lower()
-                == "on"
+            mute_val = await VizioAsync.get_audio_setting(
+                self, "mute", log_api_exception=log_api_exception
             )
-        except AttributeError:
+        except (VizioError, AttributeError):
             return None
+        if mute_val is None:
+            return None
+        return str(mute_val).lower() == "on"
 
     def get_max_volume(self) -> int:
         """Get device's max volume based on device type."""
@@ -561,12 +803,40 @@ class VizioAsync:
         return await self.__remote("CH_PREV", log_api_exception=log_api_exception)
 
     async def mute_on(self, log_api_exception: bool = True) -> bool | None:
-        """Asynchronously mute sound."""
-        return await self.__remote("MUTE_ON", log_api_exception=log_api_exception)
+        """Asynchronously mute sound (idempotent — no-op if already muted).
+
+        Verified live on VHD24M-0810 fw 3.720.9.1-1: discrete
+        ``MUTE_ON`` / ``MUTE_OFF`` codes don't actually exist as
+        discrete actions on TVs — codeset 5 codes 2/3/4 all behave
+        as toggles. ``MUTE_TOGGLE`` is the only universally reliable
+        behavior, so this method reads current mute state and sends
+        the toggle only on mismatch.
+
+        Returns ``None`` when the state probe fails (transport / auth
+        error during ``is_muted``) — falling through to a blind
+        toggle would risk inverting an already-muted device. Power
+        users wanting raw codes can still call ``remote("MUTE_ON")``.
+        """
+        current = await self.is_muted(log_api_exception=log_api_exception)
+        if current is True:
+            return True
+        if current is None:
+            return None
+        return await self.__remote("MUTE_TOGGLE", log_api_exception=log_api_exception)
 
     async def mute_off(self, log_api_exception: bool = True) -> bool | None:
-        """Asynchronously unmute sound."""
-        return await self.__remote("MUTE_OFF", log_api_exception=log_api_exception)
+        """Asynchronously unmute sound (idempotent — no-op if already unmuted).
+
+        See :meth:`mute_on` for the rationale on the read-then-toggle
+        pattern, including the ``is_muted() == None`` guard against
+        inverting an already-correct state when the probe fails.
+        """
+        current = await self.is_muted(log_api_exception=log_api_exception)
+        if current is False:
+            return True
+        if current is None:
+            return None
+        return await self.__remote("MUTE_TOGGLE", log_api_exception=log_api_exception)
 
     async def mute_toggle(self, log_api_exception: bool = True) -> bool | None:
         """Asynchronously toggle sound mute."""
@@ -1006,6 +1276,7 @@ if TYPE_CHECKING:
         def get_setting_options(self, setting_type: str, setting_name: str, log_api_exception: bool = True) -> list[str] | dict[str, int | None] | None: ...  # type: ignore[override]
         def get_setting_options_xlist(self, setting_type: str, setting_name: str, log_api_exception: bool = True) -> list[str] | None: ...  # type: ignore[override]
         def get_setting_types_list(self, log_api_exception: bool = True) -> list[str] | None: ...  # type: ignore[override]
+        def get_state_extended(self, log_api_exception: bool = True) -> StateExtended | None: ...  # type: ignore[override]
         def get_version(self, log_api_exception: bool = True) -> str | None: ...  # type: ignore[override]
         def is_muted(self, log_api_exception: bool = True) -> bool | None: ...  # type: ignore[override]
         def launch_app(self, app_name: str, apps_list: list[dict[str, Any]] | None = None, log_api_exception: bool = True) -> bool | None: ...  # type: ignore[override]

--- a/pyvizio/__init__.py
+++ b/pyvizio/__init__.py
@@ -225,6 +225,7 @@ class VizioAsync:
         cmd: CommandBase,
         log_api_exception: bool = True,
         propagate_errors: bool = False,
+        skip_envelope: bool = False,
     ) -> Any:
         """Asynchronously call SmartCast API without auth token."""
         async with self._get_semaphore():
@@ -238,6 +239,7 @@ class VizioAsync:
                 custom_timeout=self._timeout,
                 log_api_exception=log_api_exception,
                 session=self._session,
+                skip_envelope=skip_envelope,
                 propagate_errors=propagate_errors,
             )
 
@@ -285,6 +287,7 @@ class VizioAsync:
                     cmd,
                     log_api_exception=log_api_exception,
                     propagate_errors=propagate_errors,
+                    skip_envelope=skip_envelope,
                 )
             else:
                 no_auth_types = [
@@ -359,6 +362,20 @@ class VizioAsync:
         """
         if self._cached_identity_loaded:
             return self._cached_identity
+        # Probe-style callers (empty auth_token) on a device class that
+        # requires auth would receive a 401/403 from the no-auth
+        # aggregate call, which propagates as ``VizioAuthError`` and
+        # would break the caller's bool/None contract (e.g.
+        # ``get_unique_id`` is documented to return ``str | None``).
+        # Skip the aggregate entirely in that case and let the caller
+        # fall through to the per-field paths, which historically work
+        # without auth on the same firmware.
+        if (
+            not require_auth
+            and not self._auth_token
+            and self._device_config.requires_auth
+        ):
+            return None
         for endpoint_key in ("TV_INFORMATION", "_ALT_TV_INFORMATION"):
             if endpoint_key not in self._device_config.endpoints:
                 continue
@@ -678,8 +695,10 @@ class VizioAsync:
         Short-circuits when already on the target input — the device
         explicitly rejects "switch to current input" with FAILURE.
 
-        This issues two GETs (current input + inputs list) before the
-        PUT to perform the name → cname resolution.
+        Issues two GETs unconditionally — current_input (for the
+        hashval and the short-circuit comparison) and the inputs
+        list (for cname resolution). A third request (the PUT) fires
+        only when the device is not already on the target input.
         """
         curr_input_item = await self.__invoke_api_may_need_auth(
             GetCurrentInputCommand(self.device_type),
@@ -754,9 +773,10 @@ class VizioAsync:
         raises (auth-class envelopes) accordingly.
 
         Raises :class:`VizioUnsupportedError` for device types that
-        don't expose the endpoint (speakers, Crave). The standard
-        ``log_api_exception=False`` swallow turns it back into ``None``
-        for compat callers.
+        don't expose the endpoint (speakers, Crave). This is a
+        programming-level invariant set at construction time, not a
+        runtime device condition, so it always propagates —
+        ``log_api_exception`` does not silence it.
         """
         if "STATE_EXTENDED" not in self._device_config.endpoints:
             # Device-class capability is a programming-level invariant
@@ -807,18 +827,28 @@ class VizioAsync:
                 # Definitive: this firmware doesn't expose the endpoint.
                 # Cache so the next poll doesn't re-probe.
                 self._state_extended_unavailable = True
-                if log_api_exception:
-                    _LOGGER.debug("/state_extended not exposed by this firmware")
+                _LOGGER.info(
+                    "/state_extended not exposed by %s (%s); caching as "
+                    "unavailable for the rest of this session",
+                    self.ip,
+                    self.device_type,
+                )
                 return None
             if res_lower:
-                # Other envelope statuses (BLOCKED, etc.) are transient
-                # — don't poison the capability cache.
-                if log_api_exception:
-                    _LOGGER.debug(
-                        "/state_extended returned envelope status %r — "
-                        "treating as unavailable",
-                        res,
-                    )
+                # Other envelope statuses (BLOCKED, REQUIRES_PAIRING was
+                # handled above, plus anything we don't yet model) are
+                # transient — return None for this poll without caching
+                # unavailable. Logged at WARNING (and not gated on
+                # ``log_api_exception``) because an unmodeled status
+                # signals firmware behavior the library doesn't yet
+                # understand and is worth surfacing once.
+                _LOGGER.warning(
+                    "/state_extended on %s (%s) returned envelope status "
+                    "%r — returning None for this poll (not cached)",
+                    self.ip,
+                    self.device_type,
+                    res,
+                )
                 return None
         return result
 
@@ -898,10 +928,15 @@ class VizioAsync:
         :meth:`mute_on` / :meth:`mute_off` rely on the ``None`` signal
         to avoid blindly toggling on an unknown state.
 
-        Note: every :class:`VizioError` (including :class:`VizioAuthError`
-        and :class:`VizioBusyError`) is swallowed as ``None`` here. If
-        a caller needs to distinguish auth invalidation from a transport
-        blip, call ``get_audio_setting('mute')`` directly.
+        Note: this is the **only** public method that intentionally
+        swallows :class:`VizioAuthError` (along with every other
+        :class:`VizioError`). Everywhere else in the library, auth
+        errors propagate so callers can detect re-pair invalidation.
+        Here the swallow is load-bearing for the state-aware mute
+        contract — but if a caller needs to distinguish auth
+        invalidation from a transport blip on the mute probe
+        specifically, they should call ``get_audio_setting('mute')``
+        directly.
         """
         try:
             mute_val = await VizioAsync.get_audio_setting(

--- a/pyvizio/__init__.py
+++ b/pyvizio/__init__.py
@@ -74,6 +74,7 @@ from pyvizio.errors import (
     VizioBusyError as VizioBusyError,
     VizioConnectionError as VizioConnectionError,
     VizioError as VizioError,
+    VizioHashvalError as VizioHashvalError,
     VizioInvalidInputError,
     VizioInvalidParameterError as VizioInvalidParameterError,
     VizioNotFoundError as VizioNotFoundError,
@@ -122,10 +123,17 @@ def _resolve_input_cname(name: str, inputs: list[InputItem]) -> str:
                 f"({[h.c_name for h in hits]}); rename one to disambiguate"
             )
 
+    # Build a deduplicated list of valid identifiers, normalized to
+    # lowercase and stripped of empties so the user-facing error
+    # message is clean.
     valid = sorted(
-        {(i.c_name or "").lower() for i in inputs}
-        | {i.name or "" for i in inputs}
-        | {i.meta_name or "" for i in inputs if i.meta_name}
+        v.lower()
+        for v in (
+            {i.c_name or "" for i in inputs}
+            | {i.name or "" for i in inputs}
+            | {i.meta_name or "" for i in inputs if i.meta_name}
+        )
+        if v
     )
     raise VizioInvalidInputError(f"input {name!r} not found. Valid: {valid}")
 
@@ -173,6 +181,11 @@ class VizioAsync:
         # aggregate would each pay the round-trip + URI_NOT_FOUND.
         self._cached_identity: dict[str, str] | None = None
         self._cached_identity_loaded: bool = False
+        # Capability cache for /state_extended. Once a device has
+        # answered URI_NOT_FOUND we don't re-probe — capabilities are
+        # immutable for the session, and HA-style polling otherwise
+        # pays the round trip on every poll cycle.
+        self._state_extended_unavailable: bool = False
 
     def __repr__(self) -> str:
         return f"{type(self).__name__}({self.__dict__})"
@@ -208,7 +221,10 @@ class VizioAsync:
             await self.__add_port()
 
     async def __invoke_api(
-        self, cmd: CommandBase, log_api_exception: bool = True
+        self,
+        cmd: CommandBase,
+        log_api_exception: bool = True,
+        propagate_errors: bool = False,
     ) -> Any:
         """Asynchronously call SmartCast API without auth token."""
         async with self._get_semaphore():
@@ -222,6 +238,7 @@ class VizioAsync:
                 custom_timeout=self._timeout,
                 log_api_exception=log_api_exception,
                 session=self._session,
+                propagate_errors=propagate_errors,
             )
 
     async def __invoke_api_auth(
@@ -229,11 +246,14 @@ class VizioAsync:
         cmd: CommandBase,
         log_api_exception: bool = True,
         skip_envelope: bool = False,
+        propagate_errors: bool = False,
     ) -> Any:
         """Asynchronously call SmartCast API with auth token.
 
         ``skip_envelope=True`` is for endpoints with non-standard
         response shapes (currently only ``/state_extended``).
+        ``propagate_errors=True`` re-raises typed VizioError instead of
+        returning ``None`` — used by multi-path-fallback callers.
         """
         async with self._get_semaphore():
             if ":" not in self.ip:
@@ -248,15 +268,24 @@ class VizioAsync:
                 log_api_exception=log_api_exception,
                 session=self._session,
                 skip_envelope=skip_envelope,
+                propagate_errors=propagate_errors,
             )
 
     async def __invoke_api_may_need_auth(
-        self, cmd: CommandBase, log_api_exception: bool = True
+        self,
+        cmd: CommandBase,
+        log_api_exception: bool = True,
+        propagate_errors: bool = False,
+        skip_envelope: bool = False,
     ) -> Any:
         """Asynchronously call SmartCast API command with or without auth token depending on device type."""
         if not self._auth_token:
             if not self._device_config.requires_auth:
-                return await self.__invoke_api(cmd, log_api_exception=log_api_exception)
+                return await self.__invoke_api(
+                    cmd,
+                    log_api_exception=log_api_exception,
+                    propagate_errors=propagate_errors,
+                )
             else:
                 no_auth_types = [
                     k for k, v in DEVICE_CONFIGS.items() if not v.requires_auth
@@ -265,7 +294,12 @@ class VizioAsync:
                     f"Empty auth token. Device types that don't require auth: "
                     f"{', '.join(repr(t) for t in no_auth_types)}"
                 )
-        return await self.__invoke_api_auth(cmd, log_api_exception=log_api_exception)
+        return await self.__invoke_api_auth(
+            cmd,
+            log_api_exception=log_api_exception,
+            propagate_errors=propagate_errors,
+            skip_envelope=skip_envelope,
+        )
 
     async def __remote(
         self, key_list: str | list[str], log_api_exception: bool = True
@@ -300,37 +334,66 @@ class VizioAsync:
         return await self.__remote(key_codes, log_api_exception=log_api_exception)
 
     async def __get_identity_aggregate(
-        self, log_api_exception: bool = True
+        self,
+        log_api_exception: bool = True,
+        require_auth: bool = True,
     ) -> dict[str, str] | None:
         """Asynchronously fetch the aggregate ``tv_information`` envelope.
 
         Result is cached on the instance — identity is immutable for a
-        device's lifetime. Three identity calls (esn + serial_number +
-        version) now make one HTTP round trip instead of three when the
-        aggregate is exposed.
+        device's lifetime. When the aggregate is exposed, three identity
+        calls (esn + serial_number + version) make one HTTP round trip
+        instead of three.
 
-        Returns a ``cname → value`` mapping, or ``None`` when the
-        aggregate isn't exposed at either path. Returning ``None`` is
-        cached too, so older firmware that requires per-field paths
-        doesn't re-pay the URI_NOT_FOUND round trip on every call.
+        Cache write rules:
+          * Mapping returned: cache the mapping.
+          * Every candidate path returned ``URI_NOT_FOUND``: cache
+            ``None`` (this firmware definitively doesn't expose the
+            aggregate, so identity getters can stop trying).
+          * Transient failure (transport, auth, busy, malformed): do
+            **not** cache; the next call will re-attempt.
+
+        ``VizioAuthError`` always propagates — callers like
+        ``can_connect_with_auth_check`` rely on the typed exception to
+        distinguish "token invalidated" from generic failure.
         """
         if self._cached_identity_loaded:
             return self._cached_identity
-        self._cached_identity_loaded = True
         for endpoint_key in ("TV_INFORMATION", "_ALT_TV_INFORMATION"):
             if endpoint_key not in self._device_config.endpoints:
                 continue
             try:
-                mapping = await self.__invoke_api_may_need_auth(
-                    GetTvInformationCommand(self.device_type, endpoint_key),
-                    log_api_exception=log_api_exception,
-                )
-            except VizioError:
+                # Probe-style identity calls (e.g. get_unique_id, which
+                # uses an empty auth_token) need the no-auth invoker.
+                # ESN-bearing callers want the auth-aware invoker so the
+                # device returns the auth-gated fields.
+                if require_auth:
+                    mapping = await self.__invoke_api_may_need_auth(
+                        GetTvInformationCommand(self.device_type, endpoint_key),
+                        log_api_exception=log_api_exception,
+                        # Propagate typed errors so we can distinguish
+                        # "not exposed at this path" (URI_NOT_FOUND →
+                        # try next candidate) from transient/auth
+                        # failures (don't cache; retry next call).
+                        propagate_errors=True,
+                    )
+                else:
+                    mapping = await self.__invoke_api(
+                        GetTvInformationCommand(self.device_type, endpoint_key),
+                        log_api_exception=log_api_exception,
+                        propagate_errors=True,
+                    )
+            except VizioNotFoundError:
                 continue
             if mapping:
                 self._cached_identity = mapping
+                self._cached_identity_loaded = True
                 return mapping
+        # Every candidate either returned URI_NOT_FOUND or returned an
+        # empty mapping. Cache the negative result so identity getters
+        # stop probing the aggregate on every call.
         self._cached_identity = None
+        self._cached_identity_loaded = True
         return None
 
     async def __get_cached_apps_list(self) -> list[dict[str, Any]]:
@@ -417,11 +480,10 @@ class VizioAsync:
         """Asynchronously return whether or not device API can be connected to with valid authorization.
 
         Probe-style helper — must always return a bool, never propagate.
-        With the new HTTP 401/403 → :class:`VizioAuthError` mapping
-        (re-pair invalidation surfaces here), the underlying call now
-        raises that exception instead of being suppressed by
-        ``log_api_exception=False`` — the propagation is load-bearing
-        for non-probe callers, but here we want the bool contract.
+        HTTP 401/403 raises :class:`VizioAuthError` from the transport;
+        non-probe callers rely on that propagation to detect re-pair
+        invalidation, so this probe catches it locally and surfaces it
+        as a ``False`` result.
         """
         try:
             return bool(
@@ -442,9 +504,18 @@ class VizioAsync:
         """Asynchronously get device's ESN (electronic serial number?).
 
         Prefers the aggregate ``TV_INFORMATION`` endpoint; falls back
-        to per-field ``ESN`` / ``_ALT_ESN`` paths for older firmware.
+        to per-field ``ESN`` / ``_ALT_ESN`` paths for older firmware
+        or after a transient aggregate failure. ``VizioAuthError``
+        always propagates.
         """
-        agg = await self.__get_identity_aggregate(log_api_exception=log_api_exception)
+        try:
+            agg = await self.__get_identity_aggregate(
+                log_api_exception=log_api_exception
+            )
+        except VizioAuthError:
+            raise
+        except VizioError:
+            agg = None
         if agg and agg.get("esn"):
             return agg["esn"]
 
@@ -465,9 +536,17 @@ class VizioAsync:
         """Asynchronously get device's serial number.
 
         Prefers the aggregate ``TV_INFORMATION`` endpoint; falls back
-        to per-field paths for older firmware.
+        to per-field paths for older firmware or after a transient
+        aggregate failure. ``VizioAuthError`` always propagates.
         """
-        agg = await self.__get_identity_aggregate(log_api_exception=log_api_exception)
+        try:
+            agg = await self.__get_identity_aggregate(
+                log_api_exception=log_api_exception, require_auth=False
+            )
+        except VizioAuthError:
+            raise
+        except VizioError:
+            agg = None
         if agg and agg.get("serial_number"):
             return agg["serial_number"]
 
@@ -491,9 +570,18 @@ class VizioAsync:
 
         Prefers the aggregate ``TV_INFORMATION`` endpoint, where the
         version is exposed under cname ``"firmware"`` (modern firmware)
-        or ``"version"`` (older). Falls back to per-field paths.
+        or ``"version"`` (older). Falls back to per-field paths for
+        older firmware or after a transient aggregate failure.
+        ``VizioAuthError`` always propagates.
         """
-        agg = await self.__get_identity_aggregate(log_api_exception=log_api_exception)
+        try:
+            agg = await self.__get_identity_aggregate(
+                log_api_exception=log_api_exception, require_auth=False
+            )
+        except VizioAuthError:
+            raise
+        except VizioError:
+            agg = None
         if agg:
             for cname in ("version", "firmware"):
                 if agg.get(cname):
@@ -589,6 +677,9 @@ class VizioAsync:
 
         Short-circuits when already on the target input — the device
         explicitly rejects "switch to current input" with FAILURE.
+
+        This issues two GETs (current input + inputs list) before the
+        PUT to perform the name → cname resolution.
         """
         curr_input_item = await self.__invoke_api_may_need_auth(
             GetCurrentInputCommand(self.device_type),
@@ -621,10 +712,16 @@ class VizioAsync:
             None,
         )
         if target_input and isinstance(curr_input_item.value, str):
+            # Drop empty strings so a missing meta_name doesn't make the
+            # short-circuit match an empty-string current_value.
             candidates = {
-                target_cname,
-                (target_input.name or "").lower(),
-                (target_input.meta_name or "").lower(),
+                c
+                for c in (
+                    target_cname,
+                    (target_input.name or "").lower(),
+                    (target_input.meta_name or "").lower(),
+                )
+                if c
             }
             if curr_input_item.value.lower() in candidates:
                 return True
@@ -642,28 +739,40 @@ class VizioAsync:
         Returns power, current input, current app, screen mode, and
         media state — meaningfully cheaper than five individual GETs
         for HA-style polling integrations. Capability is advertised
-        under ``deviceinfo.scpl_capabilities.state_extended``; older
-        firmware that doesn't expose the endpoint surfaces as ``None``
-        (the underlying :class:`VizioNotFoundError` is suppressed by
-        the standard ``log_api_exception`` path).
+        under ``deviceinfo.scpl_capabilities.state_extended``.
 
-        The on-the-wire envelope is **distinct** from the regular
-        SCPL response shape — flat top-level keys, no
-        ``STATUS``/``ITEMS`` — so we invoke with
-        ``skip_envelope=True`` and detect URI_NOT_FOUND-shaped
-        fall-through manually.
+        The on-the-wire success payload is **distinct** from the
+        regular SCPL response shape — flat top-level keys, no
+        ``STATUS``/``ITEMS`` — so this method invokes with
+        ``skip_envelope=True``. When the device instead returns a
+        normal SCPL envelope (older firmware that doesn't expose the
+        endpoint, or transient errors like ``BLOCKED`` /
+        ``REQUIRES_PAIRING``), the bypassed validator would let the
+        parser silently produce a default-filled ``StateExtended``;
+        this method detects any ``STATUS.RESULT`` envelope on the raw
+        payload and returns ``None`` (URI_NOT_FOUND, BLOCKED) or
+        raises (auth-class envelopes) accordingly.
 
-        Returns ``None`` for device types that don't expose the
-        endpoint (speakers, Crave) — they have no ``STATE_EXTENDED``
-        in :data:`DEVICE_CONFIGS`.
+        Raises :class:`VizioUnsupportedError` for device types that
+        don't expose the endpoint (speakers, Crave). The standard
+        ``log_api_exception=False`` swallow turns it back into ``None``
+        for compat callers.
         """
         if "STATE_EXTENDED" not in self._device_config.endpoints:
-            if log_api_exception:
-                _LOGGER.debug("%r doesn't expose /state_extended", self.device_type)
+            # Device-class capability is a programming-level invariant
+            # (set by the constructor), not a runtime device condition,
+            # so this always raises — the swallow-and-return-None path
+            # is reserved for transport / device failures.
+            raise VizioUnsupportedError(
+                f"{self.device_type!r} doesn't expose /state_extended"
+            )
+        if self._state_extended_unavailable:
+            # Earlier call definitively confirmed the firmware doesn't
+            # expose this endpoint; don't re-probe.
             return None
 
         try:
-            result = await self.__invoke_api_auth(
+            result = await self.__invoke_api_may_need_auth(
                 GetStateExtendedCommand(self.device_type),
                 log_api_exception=log_api_exception,
                 skip_envelope=True,
@@ -678,19 +787,38 @@ class VizioAsync:
         if result is None:
             return None
 
-        # ``skip_envelope`` bypassed standard validation, so older
-        # firmware that returns the SCPL envelope ``{"STATUS":
-        # {"RESULT": "URI_NOT_FOUND", ...}}`` here would otherwise
-        # produce a default-filled StateExtended that callers can't
-        # distinguish from a real all-default state. Detect that
-        # shape manually and treat as "endpoint unsupported".
+        # ``skip_envelope`` bypassed standard validation. Detect any
+        # SCPL-envelope-shaped error here so callers can't be confused
+        # by a default-filled StateExtended:
+        #   * URI_NOT_FOUND  → endpoint not exposed → return None
+        #   * BLOCKED        → device busy           → return None
+        #   * REQUIRES_PAIRING / PAIRING_DENIED → re-raise VizioAuthError
+        #   * other unrecognized → return None (defensive)
         raw = result.raw if isinstance(result, StateExtended) else {}
         status_obj = dict_get_case_insensitive(raw, "status")
         if isinstance(status_obj, dict):
             res = dict_get_case_insensitive(status_obj, "result")
-            if isinstance(res, str) and res.lower() == "uri_not_found":
+            res_lower = res.lower() if isinstance(res, str) else ""
+            if res_lower in ("requires_pairing", "pairing_denied"):
+                raise VizioAuthError(
+                    dict_get_case_insensitive(status_obj, "detail") or res_lower
+                )
+            if res_lower == "uri_not_found":
+                # Definitive: this firmware doesn't expose the endpoint.
+                # Cache so the next poll doesn't re-probe.
+                self._state_extended_unavailable = True
                 if log_api_exception:
                     _LOGGER.debug("/state_extended not exposed by this firmware")
+                return None
+            if res_lower:
+                # Other envelope statuses (BLOCKED, etc.) are transient
+                # — don't poison the capability cache.
+                if log_api_exception:
+                    _LOGGER.debug(
+                        "/state_extended returned envelope status %r — "
+                        "treating as unavailable",
+                        res,
+                    )
                 return None
         return result
 
@@ -769,12 +897,17 @@ class VizioAsync:
         read (transport / device error). The state-aware
         :meth:`mute_on` / :meth:`mute_off` rely on the ``None`` signal
         to avoid blindly toggling on an unknown state.
+
+        Note: every :class:`VizioError` (including :class:`VizioAuthError`
+        and :class:`VizioBusyError`) is swallowed as ``None`` here. If
+        a caller needs to distinguish auth invalidation from a transport
+        blip, call ``get_audio_setting('mute')`` directly.
         """
         try:
             mute_val = await VizioAsync.get_audio_setting(
                 self, "mute", log_api_exception=log_api_exception
             )
-        except (VizioError, AttributeError):
+        except VizioError:
             return None
         if mute_val is None:
             return None

--- a/pyvizio/api/_protocol.py
+++ b/pyvizio/api/_protocol.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 from logging import Logger, getLogger
+import ssl
 from typing import Any
 
 from aiohttp import ClientResponse, ClientSession, ClientTimeout
@@ -20,6 +22,7 @@ from pyvizio.errors import (
     VizioInvalidParameterError,
     VizioNotFoundError,
     VizioResponseError,
+    VizioUnsupportedError,
 )
 from pyvizio.helpers import dict_get_case_insensitive
 
@@ -160,11 +163,10 @@ async def async_validate_response(
     # URI_NOT_FOUND is HTTP-200-with-status, not HTTP 404. Modern
     # firmware uses it for paths that don't exist (per-field identity
     # leaves on firmwares that only expose the aggregate). Surface as
-    # VizioNotFoundError so callers using ``propagate_errors=True``
-    # (currently only the multi-path-fallback in
-    # ``__get_identity_aggregate``) can distinguish it from transient
-    # failures and chain to the next candidate path. Default callers
-    # see ``None`` via the standard swallow path.
+    # VizioNotFoundError so callers using ``propagate_errors=True`` can
+    # distinguish it from transient failures and chain to the next
+    # candidate path. Default callers see ``None`` via the standard
+    # swallow path.
     if result_lower == STATUS_URI_NOT_FOUND:
         raise VizioNotFoundError(detail or "endpoint not found on device")
     if result_lower == STATUS_BLOCKED:
@@ -185,23 +187,48 @@ async def _do_request(
     data: str,
     timeout: ClientTimeout,
 ) -> ClientResponse:
-    """Execute a single GET or PUT request on the given session."""
-    if method == "get":
-        _LOGGER.debug(
-            "Using Request: %s", {"method": "get", "url": url, "headers": headers}
-        )
-        return await active_session.get(
-            url=url, headers=headers, ssl=False, timeout=timeout
-        )
+    """Execute a single GET or PUT request on the given session.
 
-    headers["Content-Type"] = "application/json"
-    _LOGGER.debug(
-        "Using Request: %s",
-        {"method": "put", "url": url, "headers": headers, "data": json.loads(data)},
-    )
-    return await active_session.put(
-        url=url, data=data, headers=headers, ssl=False, timeout=timeout
-    )
+    Wraps raw transport exceptions (``aiohttp.ClientError``,
+    ``asyncio.TimeoutError``, ``OSError``, ``ssl.SSLError``) into
+    :class:`VizioConnectionError` so callers using ``propagate_errors=True``
+    in :func:`async_invoke_api` see the typed error instead of having
+    transport failures fall through the broad ``except Exception``
+    catch-all and silently become ``None`` (which would, e.g., poison
+    the identity cache in :meth:`VizioAsync.__get_identity_aggregate`).
+    """
+    try:
+        if method == "get":
+            _LOGGER.debug(
+                "Using Request: %s",
+                {"method": "get", "url": url, "headers": headers},
+            )
+            return await active_session.get(
+                url=url, headers=headers, ssl=False, timeout=timeout
+            )
+
+        headers["Content-Type"] = "application/json"
+        _LOGGER.debug(
+            "Using Request: %s",
+            {"method": "put", "url": url, "headers": headers, "data": json.loads(data)},
+        )
+        return await active_session.put(
+            url=url, data=data, headers=headers, ssl=False, timeout=timeout
+        )
+    except (asyncio.TimeoutError, OSError, ssl.SSLError) as e:
+        raise VizioConnectionError(
+            f"Transport error talking to {url}: {type(e).__name__}: {e}"
+        ) from e
+    except Exception as e:
+        # Catches aiohttp.ClientError and any other library-specific
+        # transport exceptions without import-leaking aiohttp here.
+        # Re-raise non-transport bugs (anything not a recognized
+        # transport / socket failure) unchanged.
+        if e.__class__.__module__.startswith(("aiohttp", "yarl")):
+            raise VizioConnectionError(
+                f"Transport error talking to {url}: {type(e).__name__}: {e}"
+            ) from e
+        raise
 
 
 async def async_invoke_api(
@@ -257,12 +284,17 @@ async def async_invoke_api(
                 )
 
         return command.process_response(json_obj)
-    except VizioAuthError:
-        # Always propagate auth errors — callers like
-        # ``can_connect_with_auth_check`` rely on the typed exception to
-        # distinguish "token invalidated, re-pair needed" from generic
-        # network / device failures, and that distinction would be lost
-        # if we returned None.
+    except (VizioAuthError, VizioUnsupportedError):
+        # Always propagate. ``VizioAuthError`` lets probe-style callers
+        # (``can_connect_with_auth_check``) distinguish "token
+        # invalidated, re-pair needed" from generic network / device
+        # failures. ``VizioUnsupportedError`` is a programming-level
+        # invariant set at construction time (e.g. calling a TV-only
+        # endpoint on a speaker), not a runtime device condition, and
+        # must never be silently swallowed. No-op today since the only
+        # raiser (``get_state_extended``) raises before invoking the
+        # API, but locks the contract in case the capability gate ever
+        # moves inside an invoker.
         raise
     except VizioError as e:
         if propagate_errors:

--- a/pyvizio/api/_protocol.py
+++ b/pyvizio/api/_protocol.py
@@ -15,6 +15,8 @@ from pyvizio.errors import (
     VizioAuthError,
     VizioBusyError,
     VizioConnectionError,
+    VizioError,
+    VizioHashvalError,
     VizioInvalidParameterError,
     VizioNotFoundError,
     VizioResponseError,
@@ -145,17 +147,24 @@ async def async_validate_response(
     result_lower = result_status.lower() if result_status else ""
     detail = dict_get_case_insensitive(status_obj, "detail") or ""
 
-    # Both INVALID_PARAMETER and HASHVAL_ERROR map to the same exception
-    # so any caller's existing retry logic fires for both. Captured live:
-    # stale-hashval PUTs return HASHVAL_ERROR on modern firmware,
-    # INVALID_PARAMETER on older.
-    if result_lower in (STATUS_INVALID_PARAMETER, STATUS_HASHVAL_ERROR):
+    # HASHVAL_ERROR gets a more specific subclass so callers that want
+    # to retry on stale-hashval (refetch + resend) can do so without
+    # broadening to all invalid-parameter errors. Existing
+    # ``except VizioInvalidParameterError`` blocks still catch it via
+    # the parent. Captured live: stale-hashval PUTs return HASHVAL_ERROR
+    # on modern firmware, INVALID_PARAMETER on older.
+    if result_lower == STATUS_HASHVAL_ERROR:
+        raise VizioHashvalError(detail or "stale hashval — refetch and retry")
+    if result_lower == STATUS_INVALID_PARAMETER:
         raise VizioInvalidParameterError(detail or "invalid value specified")
     # URI_NOT_FOUND is HTTP-200-with-status, not HTTP 404. Modern
     # firmware uses it for paths that don't exist (per-field identity
     # leaves on firmwares that only expose the aggregate). Surface as
-    # VizioNotFoundError so multi-path-fallback callers can chain to
-    # the next candidate path.
+    # VizioNotFoundError so callers using ``propagate_errors=True``
+    # (currently only the multi-path-fallback in
+    # ``__get_identity_aggregate``) can distinguish it from transient
+    # failures and chain to the next candidate path. Default callers
+    # see ``None`` via the standard swallow path.
     if result_lower == STATUS_URI_NOT_FOUND:
         raise VizioNotFoundError(detail or "endpoint not found on device")
     if result_lower == STATUS_BLOCKED:
@@ -204,12 +213,21 @@ async def async_invoke_api(
     log_api_exception: bool = True,
     session: ClientSession = None,
     skip_envelope: bool = False,
+    propagate_errors: bool = False,
 ) -> Any:
     """Call API endpoints with appropriate request bodies and headers.
 
     ``skip_envelope=True`` forwards to :func:`async_validate_response` to
     skip SCPL ``STATUS``/``ITEMS`` validation for endpoints with
     non-standard response shapes (e.g. ``/state_extended``).
+
+    ``propagate_errors=True`` re-raises every :class:`VizioError` instead
+    of returning ``None``. Used by callers (e.g. multi-path-fallback
+    helpers like ``__get_identity_aggregate``) that need to distinguish
+    typed failure modes — ``VizioNotFoundError`` for "not exposed at
+    this path, try next" vs transport/busy errors that should not poison
+    a cache. ``VizioAuthError`` always propagates regardless of this
+    flag.
     """
     if headers is None:
         headers = {}
@@ -246,6 +264,12 @@ async def async_invoke_api(
         # network / device failures, and that distinction would be lost
         # if we returned None.
         raise
+    except VizioError as e:
+        if propagate_errors:
+            raise
+        if log_api_exception:
+            logger.error("Failed to execute command: %s", e)
+        return None
     except Exception as e:
         if log_api_exception:
             logger.error("Failed to execute command: %s", e)
@@ -262,6 +286,7 @@ async def async_invoke_api_auth(
     log_api_exception: bool = True,
     session: ClientSession = None,
     skip_envelope: bool = False,
+    propagate_errors: bool = False,
 ) -> Any:
     """Call auth protected API endpoints using CommandBase and subclass request bodies."""
 
@@ -274,4 +299,5 @@ async def async_invoke_api_auth(
         log_api_exception=log_api_exception,
         session=session,
         skip_envelope=skip_envelope,
+        propagate_errors=propagate_errors,
     )

--- a/pyvizio/api/_protocol.py
+++ b/pyvizio/api/_protocol.py
@@ -12,8 +12,11 @@ from aiohttp.client import DEFAULT_TIMEOUT as AIOHTTP_DEFAULT_TIMEOUT
 from pyvizio.api.base import CommandBase
 from pyvizio.const import DEVICE_CLASS_SPEAKER, DEVICE_CLASS_TV, DEVICE_CONFIGS
 from pyvizio.errors import (
+    VizioAuthError,
+    VizioBusyError,
     VizioConnectionError,
     VizioInvalidParameterError,
+    VizioNotFoundError,
     VizioResponseError,
 )
 from pyvizio.helpers import dict_get_case_insensitive
@@ -29,6 +32,10 @@ HEADER_AUTH = "AUTH"
 STATUS_SUCCESS = "success"
 STATUS_URI_NOT_FOUND = "uri_not_found"
 STATUS_INVALID_PARAMETER = "invalid_parameter"
+STATUS_HASHVAL_ERROR = "hashval_error"
+STATUS_BLOCKED = "blocked"
+STATUS_REQUIRES_PAIRING = "requires_pairing"
+STATUS_PAIRING_DENIED = "pairing_denied"
 
 TYPE_SLIDER = "t_value_abs_v1"
 TYPE_LIST = "t_list_v1"
@@ -86,20 +93,48 @@ class ResponseKey:
     CENTER = "center"
 
 
-async def async_validate_response(web_response: ClientResponse) -> dict[str, Any]:
-    """Validate response to API command is as expected and return response."""
+async def async_validate_response(
+    web_response: ClientResponse, *, skip_envelope: bool = False
+) -> dict[str, Any]:
+    """Validate response to API command is as expected and return response.
+
+    When ``skip_envelope`` is True the HTTP-level checks still apply
+    (200 vs 401/403/etc.) but the SCPL ``STATUS``/``ITEMS`` envelope
+    validation is skipped — used for non-standard endpoints like
+    ``/state_extended`` whose payloads use flat top-level keys with
+    no envelope wrapper.
+    """
+    # Auth-related rejections come back as raw HTTP 401/403 (not as
+    # SCPL envelope errors). Verified live on VHD24M-0810 fw 3.720.9.1-1:
+    # re-pairing with the same device_id immediately invalidates the
+    # previous token, and subsequent calls with the old token return
+    # raw HTTP 403 (not the PAIRING_DENIED envelope).
+    if web_response.status in (401, 403):
+        raise VizioAuthError(
+            f"device returned HTTP {web_response.status} — token rejected "
+            f"(may have been invalidated by re-pair)"
+        )
     if HTTP_OK != web_response.status:
         raise VizioConnectionError(
             f"Device is unreachable? Status code: {web_response.status}"
         )
 
     try:
-        data = json.loads(await web_response.text())
-        _LOGGER.debug("Response: %s", data)
+        body_text = await web_response.text()
     except Exception as err:
         raise VizioResponseError(
-            f"Failed to parse response: {web_response.content}"
+            "Failed to read response body (transport error)"
         ) from err
+    try:
+        data = json.loads(body_text)
+        _LOGGER.debug("Response: %s", data)
+    except ValueError as err:
+        raise VizioResponseError(
+            f"Failed to parse response body (truncated to 200 chars): {body_text[:200]}"
+        ) from err
+
+    if skip_envelope:
+        return data
 
     status_obj = dict_get_case_insensitive(data, "status")
 
@@ -107,15 +142,28 @@ async def async_validate_response(web_response: ClientResponse) -> dict[str, Any
         raise VizioResponseError("Unknown response")
 
     result_status = dict_get_case_insensitive(status_obj, "result")
+    result_lower = result_status.lower() if result_status else ""
+    detail = dict_get_case_insensitive(status_obj, "detail") or ""
 
-    if result_status and result_status.lower() == STATUS_INVALID_PARAMETER:
-        raise VizioInvalidParameterError("invalid value specified")
-    elif not result_status or result_status.lower() != STATUS_SUCCESS:
-        raise VizioResponseError(
-            "unexpected status {}: {}".format(
-                result_status, dict_get_case_insensitive(status_obj, "detail")
-            )
-        )
+    # Both INVALID_PARAMETER and HASHVAL_ERROR map to the same exception
+    # so any caller's existing retry logic fires for both. Captured live:
+    # stale-hashval PUTs return HASHVAL_ERROR on modern firmware,
+    # INVALID_PARAMETER on older.
+    if result_lower in (STATUS_INVALID_PARAMETER, STATUS_HASHVAL_ERROR):
+        raise VizioInvalidParameterError(detail or "invalid value specified")
+    # URI_NOT_FOUND is HTTP-200-with-status, not HTTP 404. Modern
+    # firmware uses it for paths that don't exist (per-field identity
+    # leaves on firmwares that only expose the aggregate). Surface as
+    # VizioNotFoundError so multi-path-fallback callers can chain to
+    # the next candidate path.
+    if result_lower == STATUS_URI_NOT_FOUND:
+        raise VizioNotFoundError(detail or "endpoint not found on device")
+    if result_lower == STATUS_BLOCKED:
+        raise VizioBusyError(detail or "device blocked the request")
+    if result_lower in (STATUS_REQUIRES_PAIRING, STATUS_PAIRING_DENIED):
+        raise VizioAuthError(detail or result_lower)
+    if result_lower != STATUS_SUCCESS:
+        raise VizioResponseError(f"unexpected status {result_status}: {detail}")
 
     return data
 
@@ -155,8 +203,14 @@ async def async_invoke_api(
     headers: dict[str, Any] = None,
     log_api_exception: bool = True,
     session: ClientSession = None,
+    skip_envelope: bool = False,
 ) -> Any:
-    """Call API endpoints with appropriate request bodies and headers."""
+    """Call API endpoints with appropriate request bodies and headers.
+
+    ``skip_envelope=True`` forwards to :func:`async_validate_response` to
+    skip SCPL ``STATUS``/``ITEMS`` validation for endpoints with
+    non-standard response shapes (e.g. ``/state_extended``).
+    """
     if headers is None:
         headers = {}
     url = f"https://{ip}{command.get_url()}"
@@ -172,15 +226,26 @@ async def async_invoke_api(
     try:
         if session:
             response = await _do_request(session, method, url, headers, data, timeout)
-            json_obj = await async_validate_response(response)
+            json_obj = await async_validate_response(
+                response, skip_envelope=skip_envelope
+            )
         else:
             async with ClientSession() as local_session:
                 response = await _do_request(
                     local_session, method, url, headers, data, timeout
                 )
-                json_obj = await async_validate_response(response)
+                json_obj = await async_validate_response(
+                    response, skip_envelope=skip_envelope
+                )
 
         return command.process_response(json_obj)
+    except VizioAuthError:
+        # Always propagate auth errors — callers like
+        # ``can_connect_with_auth_check`` rely on the typed exception to
+        # distinguish "token invalidated, re-pair needed" from generic
+        # network / device failures, and that distinction would be lost
+        # if we returned None.
+        raise
     except Exception as e:
         if log_api_exception:
             logger.error("Failed to execute command: %s", e)
@@ -196,6 +261,7 @@ async def async_invoke_api_auth(
     custom_timeout: int = None,
     log_api_exception: bool = True,
     session: ClientSession = None,
+    skip_envelope: bool = False,
 ) -> Any:
     """Call auth protected API endpoints using CommandBase and subclass request bodies."""
 
@@ -207,4 +273,5 @@ async def async_invoke_api_auth(
         headers={HEADER_AUTH: auth_token},
         log_api_exception=log_api_exception,
         session=session,
+        skip_envelope=skip_envelope,
     )

--- a/pyvizio/api/item.py
+++ b/pyvizio/api/item.py
@@ -175,11 +175,15 @@ class AltItemInfoCommandBase(ItemInfoCommandBase):
 class GetTvInformationCommand(InfoCommandBase):
     """Command to GET the aggregate ``tv_information`` envelope.
 
-    Modern firmware (~3.7+, verified VHD24M-0810 fw 3.720.9.1-1) returns
-    all identity fields (esn, serial_number, firmware, version, ...) in
-    one response under the parent path, and rejects the per-field child
-    paths with ``URI_NOT_FOUND``. The library tries the aggregate first
-    and falls back to per-field endpoints on older firmware.
+    Modern firmware (~3.7+, verified VHD24M-0810 fw 3.720.9.1-1)
+    returns the ``tv_information`` identity fields (``serial_number``,
+    ``firmware``, ``version``, ``model_name``, ``tv_name``, ...) in
+    one response under the parent path, and rejects the per-field
+    children of ``tv_information/`` with ``URI_NOT_FOUND``. ``esn``
+    lives under ``uli_information/`` and is **not** part of this
+    aggregate; ``get_esn()`` always falls through to its per-field
+    path. The library tries the aggregate first and falls back to
+    per-field endpoints on older firmware.
     """
 
     def __init__(self, device_type: str, endpoint_key: str = "TV_INFORMATION") -> None:

--- a/pyvizio/api/item.py
+++ b/pyvizio/api/item.py
@@ -170,3 +170,35 @@ class AltItemInfoCommandBase(ItemInfoCommandBase):
         super(ItemInfoCommandBase, self).__init__(ENDPOINT[device_type][endpoint_name])
         self.item_name = item_name.upper()
         self.default_return = default_return
+
+
+class GetTvInformationCommand(InfoCommandBase):
+    """Command to GET the aggregate ``tv_information`` envelope.
+
+    Modern firmware (~3.7+, verified VHD24M-0810 fw 3.720.9.1-1) returns
+    all identity fields (esn, serial_number, firmware, version, ...) in
+    one response under the parent path, and rejects the per-field child
+    paths with ``URI_NOT_FOUND``. The library tries the aggregate first
+    and falls back to per-field endpoints on older firmware.
+    """
+
+    def __init__(self, device_type: str, endpoint_key: str = "TV_INFORMATION") -> None:
+        """Initialize aggregate tv_information GET command.
+
+        ``endpoint_key`` selects ``TV_INFORMATION`` (admin_and_privacy
+        path) or ``_ALT_TV_INFORMATION`` (legacy ``system`` path).
+        """
+        super().__init__(ENDPOINT[device_type][endpoint_key])
+
+    def process_response(self, json_obj: dict[str, Any]) -> dict[str, str]:
+        """Return ``cname → value`` mapping of every populated item."""
+        items = dict_get_case_insensitive(json_obj, ResponseKey.ITEMS, [])
+        mapping: dict[str, str] = {}
+        for itm in items:
+            cname = (
+                dict_get_case_insensitive(itm, ResponseKey.CNAME, "") or ""
+            ).lower()
+            value = dict_get_case_insensitive(itm, ResponseKey.VALUE)
+            if cname and value is not None:
+                mapping[cname] = str(value)
+        return mapping

--- a/pyvizio/api/state_extended.py
+++ b/pyvizio/api/state_extended.py
@@ -8,9 +8,9 @@ endpoint).
 
 Capability is advertised by the device under
 ``deviceinfo.scpl_capabilities.state_extended``. Older firmware that
-doesn't expose it returns ``URI_NOT_FOUND`` from
-:meth:`pyvizio.VizioAsync.get_state_extended`, which surfaces as
-:class:`pyvizio.errors.VizioNotFoundError`.
+doesn't expose it returns the SCPL ``URI_NOT_FOUND`` envelope;
+:meth:`pyvizio.VizioAsync.get_state_extended` detects that shape on
+the raw payload and returns ``None``.
 
 Verified live on VHD24M-0810 firmware 3.720.9.1-1.
 """
@@ -18,14 +18,22 @@ Verified live on VHD24M-0810 firmware 3.720.9.1-1.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, TypedDict
 
 from pyvizio.api.base import InfoCommandBase
 from pyvizio.const import DEVICE_CONFIGS
 from pyvizio.helpers import dict_get_case_insensitive
 
 
-@dataclass
+class CurrentApp(TypedDict):
+    """Active SmartCast app config as returned in ``/state_extended``."""
+
+    app_id: str
+    name_space: int
+    message: str | None
+
+
+@dataclass(frozen=True)
 class StateExtended:
     """Typed view of the ``/state_extended`` payload.
 
@@ -34,6 +42,8 @@ class StateExtended:
     than raising. This lets a polling integration consume one snapshot
     per loop iteration regardless of which fields the device chose
     to populate.
+
+    Frozen so cached snapshots can't be mutated by accident.
     """
 
     power_on: bool = False
@@ -44,22 +54,19 @@ class StateExtended:
     ``"Quick Start"``."""
 
     current_input: str = ""
-    """Meta-name of the active input. For consistency with
-    :meth:`pyvizio.VizioAsync.get_current_input`, this is the same
-    value the device returns for ``current_input`` — which can be
-    the cname-derived display name OR the meta_name depending on
-    input type (verified live: cast inputs return the meta_name
-    ``"SMARTCAST"`` while HDMI inputs return the display name
-    ``"HDMI-2"`` even when user-renamed)."""
+    """Device-reported current_input value. Note: shape varies by
+    input type — HDMI inputs return the cname-derived display name
+    (``"HDMI-2"``, even when user-renamed), cast inputs return the
+    meta_name (``"SMARTCAST"``). Verified live on VHD24M-0810
+    fw 3.720.9.1-1."""
 
     current_input_hashval: int | None = None
     """Hashval of the current_input setting — useful for callers that
     want to write back without an additional GET."""
 
-    current_app: dict[str, Any] | None = None
-    """Active SmartCast app config as ``{"app_id", "name_space",
-    "message"}``, or ``None`` when no app is running. For the
-    SmartCast Home screen this is populated with
+    current_app: CurrentApp | None = None
+    """Active SmartCast app config, or ``None`` when no app is running.
+    For the SmartCast Home screen this is populated with
     ``{"app_id": "1", "name_space": 4, ...}``."""
 
     screen_mode: str = ""
@@ -94,7 +101,12 @@ def parse_state_extended(payload: dict[str, Any]) -> StateExtended:
     power_status = dict_get_case_insensitive(payload, "power_status")
     power_on = False
     if isinstance(power_status, dict):
-        power_on = bool(dict_get_case_insensitive(power_status, "value", 0))
+        # Coerce via int() rather than bool(): firmware may serialize
+        # the value as the string "0" / "1", and bool("0") is True.
+        try:
+            power_on = int(dict_get_case_insensitive(power_status, "value", 0)) == 1
+        except (TypeError, ValueError):
+            power_on = False
 
     power_mode_raw = dict_get_case_insensitive(payload, "power_mode")
     power_mode = ""
@@ -113,22 +125,18 @@ def parse_state_extended(payload: dict[str, Any]) -> StateExtended:
             current_input_hashval = None
 
     app_current_raw = dict_get_case_insensitive(payload, "app_current")
-    current_app: dict[str, Any] | None = None
+    current_app: CurrentApp | None = None
     if isinstance(app_current_raw, dict):
         app_id = dict_get_case_insensitive(app_current_raw, "app_id")
         name_space = dict_get_case_insensitive(app_current_raw, "name_space")
         if app_id is not None and name_space is not None:
             try:
-                current_app = {
-                    "app_id": str(app_id),
-                    "name_space": int(name_space),
-                    "message": (
-                        str(dict_get_case_insensitive(app_current_raw, "message"))
-                        if dict_get_case_insensitive(app_current_raw, "message")
-                        is not None
-                        else None
-                    ),
-                }
+                msg_raw = dict_get_case_insensitive(app_current_raw, "message")
+                current_app = CurrentApp(
+                    app_id=str(app_id),
+                    name_space=int(name_space),
+                    message=str(msg_raw) if msg_raw is not None else None,
+                )
             except (TypeError, ValueError):
                 current_app = None
 

--- a/pyvizio/api/state_extended.py
+++ b/pyvizio/api/state_extended.py
@@ -86,7 +86,9 @@ class StateExtended:
 
     raw: dict[str, Any] = field(default_factory=dict)
     """Original parsed JSON payload. Escape hatch for fields we don't
-    model (firmware-specific extensions)."""
+    model (firmware-specific extensions). Note: the dataclass is
+    frozen, but ``raw`` is itself a dict and is shallowly mutable —
+    treat it as read-only."""
 
 
 def parse_state_extended(payload: dict[str, Any]) -> StateExtended:
@@ -162,9 +164,13 @@ def parse_state_extended(payload: dict[str, Any]) -> StateExtended:
 class GetStateExtendedCommand(InfoCommandBase):
     """Command to GET ``/state_extended`` and parse into :class:`StateExtended`.
 
-    Note: the response has a non-standard envelope (no STATUS/ITEMS),
-    so callers must invoke this command with ``skip_envelope=True``
-    against :func:`pyvizio.api._protocol.async_invoke_api_auth`.
+    Note: the success-case response has a non-standard envelope (flat
+    top-level keys, no ``STATUS``/``ITEMS`` wrapper), so callers must
+    thread ``skip_envelope=True`` through whichever invoker they use
+    (``async_invoke_api`` / ``async_invoke_api_auth``). Older firmware
+    that doesn't expose the endpoint returns the standard SCPL envelope
+    with ``RESULT: URI_NOT_FOUND``; the caller is responsible for
+    detecting that shape on the parsed payload.
     """
 
     def __init__(self, device_type: str) -> None:

--- a/pyvizio/api/state_extended.py
+++ b/pyvizio/api/state_extended.py
@@ -1,0 +1,168 @@
+"""Aggregate state snapshot from ``GET /state_extended``.
+
+Bulk poll alternative to issuing five individual GETs against power
+mode, current input, current app, screen mode, and media state.
+Returns a single response with all of the above in a flat-keyed
+envelope (no ``STATUS``/``ITEMS`` wrapper, unlike every other SCPL
+endpoint).
+
+Capability is advertised by the device under
+``deviceinfo.scpl_capabilities.state_extended``. Older firmware that
+doesn't expose it returns ``URI_NOT_FOUND`` from
+:meth:`pyvizio.VizioAsync.get_state_extended`, which surfaces as
+:class:`pyvizio.errors.VizioNotFoundError`.
+
+Verified live on VHD24M-0810 firmware 3.720.9.1-1.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from pyvizio.api.base import InfoCommandBase
+from pyvizio.const import DEVICE_CONFIGS
+from pyvizio.helpers import dict_get_case_insensitive
+
+
+@dataclass
+class StateExtended:
+    """Typed view of the ``/state_extended`` payload.
+
+    All fields are best-effort: missing values from older or partial
+    firmware degrade to empty string / ``None`` / empty tuple rather
+    than raising. This lets a polling integration consume one snapshot
+    per loop iteration regardless of which fields the device chose
+    to populate.
+    """
+
+    power_on: bool = False
+    """Derived from ``POWER_STATUS.VALUE`` (``1 = on, 0 = off``)."""
+
+    power_mode: str = ""
+    """Human-readable mode such as ``"On"``, ``"Active Off"``,
+    ``"Quick Start"``."""
+
+    current_input: str = ""
+    """Meta-name of the active input. For consistency with
+    :meth:`pyvizio.VizioAsync.get_current_input`, this is the same
+    value the device returns for ``current_input`` — which can be
+    the cname-derived display name OR the meta_name depending on
+    input type (verified live: cast inputs return the meta_name
+    ``"SMARTCAST"`` while HDMI inputs return the display name
+    ``"HDMI-2"`` even when user-renamed)."""
+
+    current_input_hashval: int | None = None
+    """Hashval of the current_input setting — useful for callers that
+    want to write back without an additional GET."""
+
+    current_app: dict[str, Any] | None = None
+    """Active SmartCast app config as ``{"app_id", "name_space",
+    "message"}``, or ``None`` when no app is running. For the
+    SmartCast Home screen this is populated with
+    ``{"app_id": "1", "name_space": 4, ...}``."""
+
+    screen_mode: str = ""
+    """e.g. ``"Full screen"``, ``"PIP"``."""
+
+    media_state: str = ""
+    """e.g. ``"MediaState::Stopped"``, ``"MediaState::Playing"``.
+    Vizio uses C++-style namespace prefixes — caller usually wants
+    ``.split("::", 1)[1]``."""
+
+    device_name: str = ""
+    """User-set TV name (e.g. ``"Living Room TV"``)."""
+
+    errors: tuple[str, ...] = ()
+    """Per-field errors reported alongside the snapshot. Empty in the
+    common case."""
+
+    raw: dict[str, Any] = field(default_factory=dict)
+    """Original parsed JSON payload. Escape hatch for fields we don't
+    model (firmware-specific extensions)."""
+
+
+def parse_state_extended(payload: dict[str, Any]) -> StateExtended:
+    """Parse the ``/state_extended`` envelope into a :class:`StateExtended`.
+
+    The on-the-wire payload uses flat top-level keys
+    (``POWER_MODE``, ``APP_CURRENT``, ``CURRENT_INPUT``, ...) with no
+    ``STATUS``/``ITEMS`` wrapper. We're tolerant of missing fields:
+    older or partial firmware degrades each field gracefully rather
+    than raising.
+    """
+    power_status = dict_get_case_insensitive(payload, "power_status")
+    power_on = False
+    if isinstance(power_status, dict):
+        power_on = bool(dict_get_case_insensitive(power_status, "value", 0))
+
+    power_mode_raw = dict_get_case_insensitive(payload, "power_mode")
+    power_mode = ""
+    if isinstance(power_mode_raw, dict):
+        power_mode = str(dict_get_case_insensitive(power_mode_raw, "value", ""))
+
+    current_input_raw = dict_get_case_insensitive(payload, "current_input")
+    current_input = ""
+    current_input_hashval: int | None = None
+    if isinstance(current_input_raw, dict):
+        current_input = str(dict_get_case_insensitive(current_input_raw, "name", ""))
+        hv = dict_get_case_insensitive(current_input_raw, "hashval")
+        try:
+            current_input_hashval = int(hv) if hv is not None else None
+        except (TypeError, ValueError):
+            current_input_hashval = None
+
+    app_current_raw = dict_get_case_insensitive(payload, "app_current")
+    current_app: dict[str, Any] | None = None
+    if isinstance(app_current_raw, dict):
+        app_id = dict_get_case_insensitive(app_current_raw, "app_id")
+        name_space = dict_get_case_insensitive(app_current_raw, "name_space")
+        if app_id is not None and name_space is not None:
+            try:
+                current_app = {
+                    "app_id": str(app_id),
+                    "name_space": int(name_space),
+                    "message": (
+                        str(dict_get_case_insensitive(app_current_raw, "message"))
+                        if dict_get_case_insensitive(app_current_raw, "message")
+                        is not None
+                        else None
+                    ),
+                }
+            except (TypeError, ValueError):
+                current_app = None
+
+    errors_raw = dict_get_case_insensitive(payload, "errors")
+    errors: tuple[str, ...] = ()
+    if isinstance(errors_raw, list):
+        errors = tuple(str(e) for e in errors_raw)
+
+    return StateExtended(
+        power_on=power_on,
+        power_mode=power_mode,
+        current_input=current_input,
+        current_input_hashval=current_input_hashval,
+        current_app=current_app,
+        screen_mode=str(dict_get_case_insensitive(payload, "screen_mode", "")),
+        media_state=str(dict_get_case_insensitive(payload, "media_state", "")),
+        device_name=str(dict_get_case_insensitive(payload, "device_name", "")),
+        errors=errors,
+        raw=dict(payload),
+    )
+
+
+class GetStateExtendedCommand(InfoCommandBase):
+    """Command to GET ``/state_extended`` and parse into :class:`StateExtended`.
+
+    Note: the response has a non-standard envelope (no STATUS/ITEMS),
+    so callers must invoke this command with ``skip_envelope=True``
+    against :func:`pyvizio.api._protocol.async_invoke_api_auth`.
+    """
+
+    def __init__(self, device_type: str) -> None:
+        """Initialize state_extended GET command."""
+        super().__init__(DEVICE_CONFIGS[device_type].endpoints["STATE_EXTENDED"])
+
+    def process_response(self, json_obj: dict[str, Any]) -> StateExtended:
+        """Parse the raw payload into a typed snapshot."""
+        return parse_state_extended(json_obj)

--- a/pyvizio/const.py
+++ b/pyvizio/const.py
@@ -85,6 +85,19 @@ DEVICE_CONFIGS: dict[str, DeviceConfig] = {
             "_ALT_ESN": "/menu_native/dynamic/tv_settings/admin_and_privacy/system_information/uli_information/esn",
             "_ALT_SERIAL_NUMBER": "/menu_native/dynamic/tv_settings/admin_and_privacy/system_information/tv_information/serial_number",
             "_ALT_VERSION": "/menu_native/dynamic/tv_settings/admin_and_privacy/system_information/tv_information/version",
+            # Aggregate identity endpoint. Modern firmware (~3.7+) returns
+            # all identity fields (tv_name, serial_number, model_name,
+            # firmware, cast_version, vizios, conjure, sc_config, ...)
+            # in one response and rejects per-field child paths above with
+            # URI_NOT_FOUND. Library tries this first; falls back to
+            # per-field paths on URI_NOT_FOUND for older firmware.
+            "TV_INFORMATION": "/menu_native/dynamic/tv_settings/admin_and_privacy/system_information/tv_information",
+            "_ALT_TV_INFORMATION": "/menu_native/dynamic/tv_settings/system/system_information/tv_information",
+            # Bulk state poll. Returns power, current input, current app,
+            # screen mode, media state in a single round trip with a
+            # flat-keyed envelope (no STATUS/ITEMS wrapper). Capability
+            # advertised under deviceinfo.scpl_capabilities.state_extended.
+            "STATE_EXTENDED": "/state_extended",
             "DEVICE_INFO": "/state/device/deviceinfo",
             "POWER_MODE": "/state/device/power_mode",
             "KEY_PRESS": "/key_command/",
@@ -125,6 +138,20 @@ DEVICE_CONFIGS: dict[str, DeviceConfig] = {
             "POW_OFF": (11, 0),
             "POW_ON": (11, 1),
             "POW_TOGGLE": (11, 2),
+            # Numeric keys for direct channel entry on tuner-equipped
+            # models. Tuner-less models (verified live on VHD24M-0810)
+            # reject these with FAILURE — better UX than absence from
+            # the keymap.
+            "NUM_0": (0, 0),
+            "NUM_1": (0, 1),
+            "NUM_2": (0, 2),
+            "NUM_3": (0, 3),
+            "NUM_4": (0, 4),
+            "NUM_5": (0, 5),
+            "NUM_6": (0, 6),
+            "NUM_7": (0, 7),
+            "NUM_8": (0, 8),
+            "NUM_9": (0, 9),
         },
     ),
     DEVICE_CLASS_SPEAKER: DeviceConfig(

--- a/pyvizio/const.py
+++ b/pyvizio/const.py
@@ -86,11 +86,14 @@ DEVICE_CONFIGS: dict[str, DeviceConfig] = {
             "_ALT_SERIAL_NUMBER": "/menu_native/dynamic/tv_settings/admin_and_privacy/system_information/tv_information/serial_number",
             "_ALT_VERSION": "/menu_native/dynamic/tv_settings/admin_and_privacy/system_information/tv_information/version",
             # Aggregate identity endpoint. Modern firmware (~3.7+) returns
-            # all identity fields (tv_name, serial_number, model_name,
-            # firmware, cast_version, vizios, conjure, sc_config, ...)
-            # in one response and rejects per-field child paths above with
-            # URI_NOT_FOUND. Library tries this first; falls back to
-            # per-field paths on URI_NOT_FOUND for older firmware.
+            # the tv_information fields (tv_name, serial_number, model_name,
+            # firmware, cast_version, vizios, conjure, sc_config, ...) in
+            # one response and rejects the per-field children of
+            # tv_information/ (SERIAL_NUMBER, VERSION above) with
+            # URI_NOT_FOUND. Note: ESN lives under uli_information/, not
+            # tv_information/, so the aggregate doesn't carry it. Library
+            # tries this first; falls back to per-field on URI_NOT_FOUND
+            # for older firmware.
             "TV_INFORMATION": "/menu_native/dynamic/tv_settings/admin_and_privacy/system_information/tv_information",
             "_ALT_TV_INFORMATION": "/menu_native/dynamic/tv_settings/system/system_information/tv_information",
             # Bulk state poll. Returns power, current input, current app,

--- a/pyvizio/errors.py
+++ b/pyvizio/errors.py
@@ -39,10 +39,18 @@ class VizioBusyError(VizioError):
 
 
 class VizioInvalidInputError(VizioInvalidParameterError):
-    """The named input does not exist on this device.
+    """The named input does not exist on this device, or matches
+    multiple inputs ambiguously.
 
     Subclass of :class:`VizioInvalidParameterError` so callers that
     catch the parent still see input-specific errors.
+
+    Note: raised by the internal input cname resolver, but the public
+    :meth:`pyvizio.VizioAsync.set_input` catches it and returns
+    ``None`` per the library's ``bool | None`` convention. Use
+    :func:`pyvizio._resolve_input_cname` directly if you need the
+    typed signal (e.g. to surface a "did you mean X?" hint to the
+    user).
     """
 
 
@@ -51,10 +59,11 @@ class VizioHashvalError(VizioInvalidParameterError):
     when constructing the PUT no longer matches the device's current
     hashval (someone else, or the iPhone app, modified the setting).
 
-    Subclass of :class:`VizioInvalidParameterError` for backward
-    compatibility — existing ``except VizioInvalidParameterError``
-    blocks still catch it. New code that wants to retry on stale
-    hashval (refetch + resend) can catch this specifically.
+    Catch this subclass specifically to drive a refetch-and-retry
+    loop (re-GET the parent setting to obtain the fresh hashval, then
+    re-issue the PUT). ``except VizioInvalidParameterError`` continues
+    to catch it via the parent for callers that want to lump all
+    invalid-parameter cases together.
     """
 
 

--- a/pyvizio/errors.py
+++ b/pyvizio/errors.py
@@ -46,6 +46,18 @@ class VizioInvalidInputError(VizioInvalidParameterError):
     """
 
 
+class VizioHashvalError(VizioInvalidParameterError):
+    """Stale hashval submitted in a write — the value the caller had
+    when constructing the PUT no longer matches the device's current
+    hashval (someone else, or the iPhone app, modified the setting).
+
+    Subclass of :class:`VizioInvalidParameterError` for backward
+    compatibility — existing ``except VizioInvalidParameterError``
+    blocks still catch it. New code that wants to retry on stale
+    hashval (refetch + resend) can catch this specifically.
+    """
+
+
 class VizioUnsupportedError(VizioError):
     """The requested operation is not supported by this device class.
 

--- a/pyvizio/errors.py
+++ b/pyvizio/errors.py
@@ -21,3 +21,34 @@ class VizioInvalidParameterError(VizioError):
 
 class VizioResponseError(VizioError):
     """Unexpected or malformed response from device."""
+
+
+class VizioNotFoundError(VizioError):
+    """Requested item not found in device response.
+
+    Also used for ``URI_NOT_FOUND`` envelope status from the device,
+    which modern firmware (~3.7+) returns for paths that aren't
+    exposed (HTTP 200 + this status, not HTTP 404).
+    """
+
+
+class VizioBusyError(VizioError):
+    """Device temporarily refused — typically returned as
+    ``RESULT: BLOCKED`` envelope status. Another writer holds a lock,
+    or the device is mid-update."""
+
+
+class VizioInvalidInputError(VizioInvalidParameterError):
+    """The named input does not exist on this device.
+
+    Subclass of :class:`VizioInvalidParameterError` so callers that
+    catch the parent still see input-specific errors.
+    """
+
+
+class VizioUnsupportedError(VizioError):
+    """The requested operation is not supported by this device class.
+
+    Raised before any HTTP work when the operation is gated by device
+    profile capabilities (e.g., battery on a TV, apps on a soundbar).
+    """

--- a/tests/test_async_api.py
+++ b/tests/test_async_api.py
@@ -131,11 +131,45 @@ class TestVolume:
         result = await vizio_tv.is_muted()
         assert result is expected
 
-    @pytest.mark.parametrize("method", ["mute_on", "mute_off", "mute_toggle"])
-    async def test_mute_commands(self, vizio_tv, mock_aio, method):
+    async def test_mute_toggle(self, vizio_tv, mock_aio):
         mock_aio.put(tv_url("KEY_PRESS"), payload=make_key_press_response())
-        result = await getattr(vizio_tv, method)()
-        assert result is True
+        assert await vizio_tv.mute_toggle() is True
+
+    @pytest.mark.parametrize(
+        "method,current_state,expects_toggle",
+        [
+            # Already in target state — short-circuits, no key press.
+            ("mute_on", "On", False),
+            ("mute_off", "Off", False),
+            # Needs to flip — sends MUTE_TOGGLE.
+            ("mute_on", "Off", True),
+            ("mute_off", "On", True),
+        ],
+    )
+    async def test_mute_state_aware(
+        self, vizio_tv, mock_aio, method, current_state, expects_toggle
+    ):
+        # State-aware mute_on / mute_off probe the mute state and only
+        # send MUTE_TOGGLE on mismatch. Verified live on VHD24M-0810
+        # fw 3.720.9.1-1: discrete MUTE_ON / MUTE_OFF codes don't
+        # exist as discrete actions — codeset 5 codes 2/3/4 all behave
+        # as toggles.
+        mock_aio.get(
+            tv_settings_url("audio", "mute"),
+            payload=make_response(items=[make_item("mute", current_state)]),
+        )
+        if expects_toggle:
+            mock_aio.put(tv_url("KEY_PRESS"), payload=make_key_press_response())
+        assert await getattr(vizio_tv, method)() is True
+
+    @pytest.mark.parametrize("method", ["mute_on", "mute_off"])
+    async def test_mute_unknown_state_returns_none(self, vizio_tv, mock_aio, method):
+        # When ``is_muted`` can't determine state (transport / device
+        # error), mute_on / mute_off return None rather than blindly
+        # toggling — a blind toggle on an unknown state could invert
+        # an already-correct one.
+        mock_aio.get(tv_settings_url("audio", "mute"), status=500)
+        assert await getattr(vizio_tv, method)() is None
 
     @pytest.mark.parametrize(
         "fixture,expected",
@@ -192,9 +226,21 @@ class TestInput:
         assert result == "HDMI-1"
 
     async def test_set_input(self, vizio_tv, mock_aio):
+        # set_input now fetches the inputs list to translate the
+        # user-provided identifier to the canonical lowercase cname
+        # (only form the device accepts in the PUT body).
         mock_aio.get(
             tv_url("CURRENT_INPUT"),
             payload=make_current_input_response("current_input", "HDMI-1", 5),
+        )
+        mock_aio.get(
+            tv_url("INPUTS"),
+            payload=make_inputs_list_response(
+                [
+                    ("hdmi1", "HDMI-1", "Living Room", 1),
+                    ("hdmi2", "HDMI-2", "Console", 2),
+                ]
+            ),
         )
         mock_aio.put(tv_url("CURRENT_INPUT"), payload=make_response())
         result = await vizio_tv.set_input("HDMI-2")

--- a/tests/test_async_api.py
+++ b/tests/test_async_api.py
@@ -171,6 +171,21 @@ class TestVolume:
         mock_aio.get(tv_settings_url("audio", "mute"), status=500)
         assert await getattr(vizio_tv, method)() is None
 
+    async def test_mute_on_key_press_failure_after_probe_returns_none(
+        self, vizio_tv, mock_aio
+    ):
+        # Probe succeeds, KEY_PRESS PUT fails. Should not falsely report
+        # success — the toggle was attempted but didn't land.
+        mock_aio.get(
+            tv_settings_url("audio", "mute"),
+            payload=make_response(items=[make_item("mute", "Off")]),
+        )
+        mock_aio.put(tv_url("KEY_PRESS"), status=500)
+        # __remote returns False on failure (result is not None == False
+        # for None), so mute_on inherits that. Either way, never True.
+        result = await vizio_tv.mute_on(log_api_exception=False)
+        assert result is not True
+
     @pytest.mark.parametrize(
         "fixture,expected",
         [
@@ -245,6 +260,65 @@ class TestInput:
         mock_aio.put(tv_url("CURRENT_INPUT"), payload=make_response())
         result = await vizio_tv.set_input("HDMI-2")
         assert result is True
+
+    @pytest.mark.parametrize(
+        "current_value,target",
+        [
+            # HDMI inputs return the display name in current_input.value
+            ("HDMI-1", "hdmi1"),
+            ("HDMI-1", "HDMI-1"),
+            ("HDMI-1", "Living Room"),  # meta_name match
+            # CAST inputs return the meta_name
+            ("SMARTCAST", "cast"),
+            ("SMARTCAST", "SMARTCAST"),
+        ],
+    )
+    async def test_set_input_short_circuits_on_already_target(
+        self, vizio_tv, mock_aio, current_value, target
+    ):
+        # Verified live: device returns FAILURE for "switch to current
+        # input." The short-circuit checks current_value against any of
+        # the target's three identifying forms (cname / display name /
+        # meta_name) since the device's current_input shape varies by
+        # input type. NO PUT mock — aioresponses raises if it fires.
+        mock_aio.get(
+            tv_url("CURRENT_INPUT"),
+            payload=make_current_input_response("current_input", current_value, 5),
+        )
+        mock_aio.get(
+            tv_url("INPUTS"),
+            payload=make_inputs_list_response(
+                [
+                    ("cast", "CAST", "SMARTCAST", 0),
+                    ("hdmi1", "HDMI-1", "Living Room", 1),
+                    ("hdmi2", "HDMI-2", "Console", 2),
+                ]
+            ),
+        )
+        assert await vizio_tv.set_input(target) is True
+
+    async def test_set_input_put_failure_returns_none(self, vizio_tv, mock_aio):
+        # PUT fails after resolution succeeds (e.g. stale hashval). The
+        # broad-catch in async_invoke_api swallows the typed error and
+        # returns None; set_input returns that None unchanged.
+        mock_aio.get(
+            tv_url("CURRENT_INPUT"),
+            payload=make_current_input_response("current_input", "HDMI-1", 5),
+        )
+        mock_aio.get(
+            tv_url("INPUTS"),
+            payload=make_inputs_list_response(
+                [
+                    ("hdmi1", "HDMI-1", "Living Room", 1),
+                    ("hdmi2", "HDMI-2", "Console", 2),
+                ]
+            ),
+        )
+        mock_aio.put(
+            tv_url("CURRENT_INPUT"),
+            payload={"STATUS": {"RESULT": "HASHVAL_ERROR", "DETAIL": "stale"}},
+        )
+        assert await vizio_tv.set_input("HDMI-2", log_api_exception=False) is None
 
     async def test_next_input(self, vizio_tv, mock_aio):
         mock_aio.put(tv_url("KEY_PRESS"), payload=make_key_press_response())

--- a/tests/test_async_api.py
+++ b/tests/test_async_api.py
@@ -171,20 +171,21 @@ class TestVolume:
         mock_aio.get(tv_settings_url("audio", "mute"), status=500)
         assert await getattr(vizio_tv, method)() is None
 
-    async def test_mute_on_key_press_failure_after_probe_returns_none(
+    async def test_mute_on_key_press_failure_after_probe_returns_false(
         self, vizio_tv, mock_aio
     ):
-        # Probe succeeds, KEY_PRESS PUT fails. Should not falsely report
-        # success — the toggle was attempted but didn't land.
+        # Probe succeeds, KEY_PRESS PUT fails. ``__remote`` returns
+        # ``False`` on PUT failure (not ``None`` — None is reserved for
+        # "probe failed, state unknown"). Asserting the exact False
+        # value catches a regression that returns None instead and
+        # vice versa.
         mock_aio.get(
             tv_settings_url("audio", "mute"),
             payload=make_response(items=[make_item("mute", "Off")]),
         )
         mock_aio.put(tv_url("KEY_PRESS"), status=500)
-        # __remote returns False on failure (result is not None == False
-        # for None), so mute_on inherits that. Either way, never True.
         result = await vizio_tv.mute_on(log_api_exception=False)
-        assert result is not True
+        assert result is False
 
     @pytest.mark.parametrize(
         "fixture,expected",

--- a/tests/test_real_device_fixes.py
+++ b/tests/test_real_device_fixes.py
@@ -1,9 +1,7 @@
-"""Tests for the new code paths added in the real-device-fixes commit.
-
-Covers status-code mappings, HTTP-status mappings, the input cname
-resolver, the aggregate identity endpoint helper, and state-aware mute.
-These are the new behaviors introduced alongside the bug-fix work; the
-existing test suite continues to cover the unchanged surface.
+"""Regression tests for the input cname resolver, envelope/HTTP status
+mapping, ``VizioAuthError`` propagation through the invoke chain, the
+aggregate ``tv_information`` identity helper (and its caching contract),
+and adjacent error-path behaviors.
 """
 
 from __future__ import annotations
@@ -158,9 +156,9 @@ class TestEnvelopeStatusMapping:
             await async_validate_response(resp)
 
     async def test_parse_failure_includes_body_snippet(self) -> None:
-        """Malformed JSON used to interpolate ``response.content`` (a
-        stream object that rendered as ``<StreamReader ...>``). Now
-        the captured text is included so reporters can paste it."""
+        """Malformed JSON surfaces as ``VizioResponseError`` whose
+        message includes up to 200 chars of the actual body, so bug
+        reporters can paste the device's real response into an issue."""
         resp = _fake_response(200, "not-json-at-all <html>broken</html>")
         with pytest.raises(VizioResponseError, match="not-json-at-all"):
             await async_validate_response(resp)
@@ -363,6 +361,56 @@ class TestIdentityAggregate:
         )
         assert await v1.get_serial_number() == "SN-FROM-V1"
         assert await v2.get_serial_number() == "SN-FROM-V2"
+
+    async def test_probe_style_with_auth_required_skips_aggregate(
+        self, mock_aio
+    ) -> None:
+        """``get_unique_id`` is documented to return ``str | None`` —
+        it must not raise. With an empty auth_token on a TV (which
+        requires auth), the aggregate call would 401/403 and
+        ``VizioAuthError`` would propagate. The aggregate helper
+        skips the aggregate entirely when probe-style + auth-required
+        so the caller falls through cleanly to the per-field path."""
+        # No mock for TV_INFORMATION — assertion is that it's never hit.
+        # If the aggregate weren't skipped, aioresponses would raise
+        # ConnectionError → wrapped → propagate → break get_unique_id.
+        mock_aio.get(
+            "https://192.168.1.100:7345/menu_native/dynamic/tv_settings/system/system_information/tv_information/serial_number",
+            payload={
+                "STATUS": {"RESULT": "SUCCESS", "DETAIL": "Success"},
+                "ITEMS": [{"CNAME": "serial_number", "VALUE": "PROBE-SN"}],
+            },
+        )
+        result = await VizioAsync.get_unique_id("192.168.1.100:7345", "tv")
+        assert result == "PROBE-SN"
+
+    async def test_aggregate_aiohttp_transport_error_does_not_poison_cache(
+        self, vizio_tv, mock_aio
+    ) -> None:
+        """A raw aiohttp transport error (DNS failure, connection
+        refused, timeout, etc.) must be wrapped into VizioConnectionError
+        in _do_request so the typed-error path in async_invoke_api fires
+        and the aggregate cache is not poisoned. Without the wrapping,
+        the bare ``except Exception`` in async_invoke_api would swallow
+        these unconditionally and ignore propagate_errors=True."""
+        import asyncio
+
+        # Simulate a raw transport-level error (not a VizioError) on
+        # the aggregate path. aioresponses raises whatever Exception
+        # subclass is passed via ``exception=``. asyncio.TimeoutError
+        # is the simplest example that's not a VizioError subclass and
+        # will hit _do_request's wrapping branch.
+        mock_aio.get(tv_url("TV_INFORMATION"), exception=asyncio.TimeoutError())
+        mock_aio.get(tv_url("SERIAL_NUMBER"), exception=asyncio.TimeoutError())
+        mock_aio.get(tv_url("_ALT_SERIAL_NUMBER"), exception=asyncio.TimeoutError())
+
+        # First call should fail cleanly (return None) without raising.
+        assert await vizio_tv.get_serial_number(log_api_exception=False) is None
+        # Cache state must NOT be marked loaded — a transient transport
+        # error on the aggregate is not a definitive "not exposed"
+        # signal, so the next call must retry rather than short-circuit.
+        assert vizio_tv._cached_identity_loaded is False
+        assert vizio_tv._cached_identity is None
 
     async def test_aggregate_transient_failure_does_not_poison_cache(
         self, vizio_tv, mock_aio

--- a/tests/test_real_device_fixes.py
+++ b/tests/test_real_device_fixes.py
@@ -1,0 +1,262 @@
+"""Tests for the new code paths added in the real-device-fixes commit.
+
+Covers status-code mappings, HTTP-status mappings, the input cname
+resolver, the aggregate identity endpoint helper, and state-aware mute.
+These are the new behaviors introduced alongside the bug-fix work; the
+existing test suite continues to cover the unchanged surface.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+from aioresponses import aioresponses
+import pytest
+
+from pyvizio import VizioAsync, _resolve_input_cname
+from pyvizio.api._protocol import async_validate_response
+from pyvizio.api.input import InputItem
+from pyvizio.errors import (
+    VizioAuthError,
+    VizioBusyError,
+    VizioConnectionError,
+    VizioInvalidInputError,
+    VizioInvalidParameterError,
+    VizioNotFoundError,
+    VizioResponseError,
+)
+from tests.conftest import (
+    AUTH_TOKEN,
+    TV_IP_PORT,
+    make_input_item,
+    tv_settings_url,
+    tv_url,
+)
+
+
+def _input_items(specs):
+    """Build a list[InputItem] from (cname, display_name, meta_name, hashval) tuples."""
+    return [InputItem(make_input_item(*s), True) for s in specs]
+
+
+# ---------------------------------------------------------------------------
+# _resolve_input_cname — pure unit, no HTTP
+# ---------------------------------------------------------------------------
+
+
+class TestResolveInputCname:
+    """The user's input identifier is resolved to the lowercase cname
+    (the only form the device accepts in PUT bodies — verified live).
+    Acceptance order: cname → meta_name → display name."""
+
+    def _inputs(self) -> list[InputItem]:
+        return _input_items(
+            [
+                ("cast", "CAST", "SMARTCAST", 1),
+                ("hdmi1", "HDMI-1", "PS5", 2),
+                ("hdmi2", "HDMI-2", "Mac", 3),
+            ]
+        )
+
+    def test_resolves_by_cname(self) -> None:
+        assert _resolve_input_cname("hdmi1", self._inputs()) == "hdmi1"
+
+    def test_resolves_by_cname_case_insensitive(self) -> None:
+        assert _resolve_input_cname("HDMI1", self._inputs()) == "hdmi1"
+
+    def test_resolves_by_meta_name(self) -> None:
+        """User-renamed input — meta_name maps back to cname."""
+        assert _resolve_input_cname("Mac", self._inputs()) == "hdmi2"
+
+    def test_resolves_by_meta_name_case_insensitive(self) -> None:
+        assert _resolve_input_cname("smartcast", self._inputs()) == "cast"
+
+    def test_resolves_by_display_name(self) -> None:
+        """User passed the cname-derived display label."""
+        assert _resolve_input_cname("HDMI-2", self._inputs()) == "hdmi2"
+
+    def test_unknown_input_raises_with_valid_list(self) -> None:
+        with pytest.raises(VizioInvalidInputError, match="not found"):
+            _resolve_input_cname("HDMI-99", self._inputs())
+
+    def test_ambiguous_meta_name_raises(self) -> None:
+        """User renamed two inputs to the same string."""
+        inputs = _input_items(
+            [
+                ("hdmi1", "HDMI-1", "Living Room", 1),
+                ("hdmi2", "HDMI-2", "Living Room", 2),
+            ]
+        )
+        with pytest.raises(VizioInvalidInputError, match="multiple"):
+            _resolve_input_cname("Living Room", inputs)
+
+
+# ---------------------------------------------------------------------------
+# Status-code mappings via async_validate_response
+# ---------------------------------------------------------------------------
+
+
+def _fake_response(status: int, body: dict | str):
+    """Build a minimal stand-in for aiohttp's ClientResponse.
+
+    ``async_validate_response`` only consumes ``.status`` and ``.text()``,
+    so we don't need a real client response — a mock is more reliable
+    than going through aioresponses just to provoke validation paths.
+    """
+    resp = MagicMock()
+    resp.status = status
+    text = body if isinstance(body, str) else json.dumps(body)
+    resp.text = AsyncMock(return_value=text)
+    return resp
+
+
+class TestEnvelopeStatusMapping:
+    """Each new envelope status maps to the correct typed exception."""
+
+    @pytest.mark.parametrize(
+        "result,exc_type",
+        [
+            ("URI_NOT_FOUND", VizioNotFoundError),
+            ("HASHVAL_ERROR", VizioInvalidParameterError),
+            ("BLOCKED", VizioBusyError),
+            ("REQUIRES_PAIRING", VizioAuthError),
+            ("PAIRING_DENIED", VizioAuthError),
+        ],
+    )
+    async def test_envelope_status_maps_to_typed_exception(
+        self, result: str, exc_type: type[Exception]
+    ) -> None:
+        resp = _fake_response(
+            200, {"STATUS": {"RESULT": result, "DETAIL": f"detail for {result}"}}
+        )
+        with pytest.raises(exc_type):
+            await async_validate_response(resp)
+
+    async def test_unrecognized_status_falls_through_to_response_error(self) -> None:
+        """Defensive: status strings we don't model still raise (don't
+        silently succeed) so future Vizio additions surface as bugs."""
+        resp = _fake_response(
+            200, {"STATUS": {"RESULT": "FUTURE_VIZIO_CODE", "DETAIL": "?"}}
+        )
+        with pytest.raises(VizioResponseError):
+            await async_validate_response(resp)
+
+    async def test_parse_failure_includes_body_snippet(self) -> None:
+        """Malformed JSON used to interpolate ``response.content`` (a
+        stream object that rendered as ``<StreamReader ...>``). Now
+        the captured text is included so reporters can paste it."""
+        resp = _fake_response(200, "not-json-at-all <html>broken</html>")
+        with pytest.raises(VizioResponseError, match="not-json-at-all"):
+            await async_validate_response(resp)
+
+
+class TestHttpStatusMapping:
+    """HTTP-level errors (not envelope-status) follow a separate path —
+    auth is the most important one because re-pair invalidation
+    surfaces as raw HTTP 403."""
+
+    @pytest.mark.parametrize("http_status", [401, 403])
+    async def test_auth_http_codes_map_to_auth_error(self, http_status: int) -> None:
+        resp = _fake_response(http_status, "")
+        with pytest.raises(VizioAuthError, match=f"HTTP {http_status}"):
+            await async_validate_response(resp)
+
+    async def test_http_500_still_connection_error(self) -> None:
+        """Non-auth HTTP errors continue to raise VizioConnectionError —
+        the 401/403 special-case must not over-broaden."""
+        resp = _fake_response(500, "")
+        with pytest.raises(VizioConnectionError, match="500"):
+            await async_validate_response(resp)
+
+
+class TestAuthErrorPropagation:
+    """``async_invoke_api`` swallows most exceptions and returns None,
+    but ``VizioAuthError`` must always propagate so probe-style helpers
+    like ``can_connect_with_auth_check`` can distinguish "token
+    invalidated, re-pair needed" from generic device unreachability."""
+
+    @pytest.fixture
+    def vizio_tv(self) -> VizioAsync:
+        return VizioAsync(
+            device_id="test",
+            ip=TV_IP_PORT,
+            name="TV",
+            auth_token=AUTH_TOKEN,
+            device_type="tv",
+        )
+
+    @pytest.fixture
+    def mock_aio(self):
+        with aioresponses() as m:
+            yield m
+
+    async def test_http_403_propagates_through_invoke_api(
+        self, vizio_tv: VizioAsync, mock_aio
+    ) -> None:
+        mock_aio.get(tv_url("INPUTS"), status=403, body="")
+        with pytest.raises(VizioAuthError):
+            await vizio_tv.get_inputs_list(log_api_exception=False)
+
+    async def test_can_connect_with_auth_check_returns_false_on_403(
+        self, vizio_tv: VizioAsync, mock_aio
+    ) -> None:
+        """The auth-check probe catches VizioAuthError locally to
+        preserve its bool contract."""
+        mock_aio.get(tv_settings_url("audio"), status=403, body="")
+        assert await vizio_tv.can_connect_with_auth_check() is False
+
+
+# ---------------------------------------------------------------------------
+# Aggregate tv_information identity helper
+# ---------------------------------------------------------------------------
+
+
+class TestIdentityAggregate:
+    """Modern firmware exposes all identity fields (serial, firmware,
+    model, …) under a single ``tv_information`` parent, and rejects
+    per-field child paths with URI_NOT_FOUND. The library prefers the
+    aggregate, falling back to per-field on URI_NOT_FOUND."""
+
+    @pytest.fixture
+    def vizio_tv(self) -> VizioAsync:
+        return VizioAsync(
+            device_id="test",
+            ip=TV_IP_PORT,
+            name="TV",
+            auth_token=AUTH_TOKEN,
+            device_type="tv",
+        )
+
+    @pytest.fixture
+    def mock_aio(self):
+        with aioresponses() as m:
+            yield m
+
+    def _aggregate_payload(self) -> dict:
+        return {
+            "STATUS": {"RESULT": "SUCCESS", "DETAIL": "Success"},
+            "ITEMS": [
+                {"CNAME": "tv_name", "VALUE": "Test TV"},
+                {"CNAME": "serial_number", "VALUE": "TEST00000000001"},
+                {"CNAME": "model_name", "VALUE": "VHD24M-0810"},
+                {"CNAME": "firmware", "VALUE": "3.720.9.1-1"},
+            ],
+        }
+
+    async def test_serial_via_aggregate(self, vizio_tv, mock_aio) -> None:
+        mock_aio.get(tv_url("TV_INFORMATION"), payload=self._aggregate_payload())
+        assert await vizio_tv.get_serial_number() == "TEST00000000001"
+
+    async def test_version_resolves_firmware_alias(self, vizio_tv, mock_aio) -> None:
+        """Modern firmware exposes the version under cname='firmware'."""
+        mock_aio.get(tv_url("TV_INFORMATION"), payload=self._aggregate_payload())
+        assert await vizio_tv.get_version() == "3.720.9.1-1"
+
+    async def test_aggregate_cached_across_calls(self, vizio_tv, mock_aio) -> None:
+        """Identity is immutable — a second identity call should reuse
+        the cached aggregate, not refetch (aioresponses raises if an
+        unmocked URL is hit)."""
+        mock_aio.get(tv_url("TV_INFORMATION"), payload=self._aggregate_payload())
+        await vizio_tv.get_serial_number()
+        assert await vizio_tv.get_version() == "3.720.9.1-1"

--- a/tests/test_real_device_fixes.py
+++ b/tests/test_real_device_fixes.py
@@ -21,6 +21,7 @@ from pyvizio.errors import (
     VizioAuthError,
     VizioBusyError,
     VizioConnectionError,
+    VizioHashvalError,
     VizioInvalidInputError,
     VizioInvalidParameterError,
     VizioNotFoundError,
@@ -88,8 +89,19 @@ class TestResolveInputCname:
                 ("hdmi2", "HDMI-2", "Living Room", 2),
             ]
         )
-        with pytest.raises(VizioInvalidInputError, match="multiple"):
+        with pytest.raises(VizioInvalidInputError, match="multiple.*by meta_name"):
             _resolve_input_cname("Living Room", inputs)
+
+    def test_ambiguous_display_name_raises(self) -> None:
+        """Two inputs with same display name (firmware oddity / corruption)."""
+        inputs = _input_items(
+            [
+                ("hdmi1", "HDMI-1", "Mac", 1),
+                ("hdmi2", "HDMI-1", "PS5", 2),
+            ]
+        )
+        with pytest.raises(VizioInvalidInputError, match="multiple.*by name"):
+            _resolve_input_cname("HDMI-1", inputs)
 
 
 # ---------------------------------------------------------------------------
@@ -118,6 +130,9 @@ class TestEnvelopeStatusMapping:
         "result,exc_type",
         [
             ("URI_NOT_FOUND", VizioNotFoundError),
+            # HASHVAL_ERROR is a subclass of VizioInvalidParameterError
+            # for backward-compat — the parent still catches it.
+            ("HASHVAL_ERROR", VizioHashvalError),
             ("HASHVAL_ERROR", VizioInvalidParameterError),
             ("BLOCKED", VizioBusyError),
             ("REQUIRES_PAIRING", VizioAuthError),
@@ -260,3 +275,123 @@ class TestIdentityAggregate:
         mock_aio.get(tv_url("TV_INFORMATION"), payload=self._aggregate_payload())
         await vizio_tv.get_serial_number()
         assert await vizio_tv.get_version() == "3.720.9.1-1"
+
+    async def test_aggregate_uri_not_found_falls_back_to_per_field(
+        self, vizio_tv, mock_aio
+    ) -> None:
+        """When the aggregate is genuinely not exposed (URI_NOT_FOUND
+        on both candidate paths), identity getters fall through to the
+        per-field paths."""
+        for endpoint in ("TV_INFORMATION", "_ALT_TV_INFORMATION"):
+            mock_aio.get(
+                tv_url(endpoint),
+                payload={"STATUS": {"RESULT": "URI_NOT_FOUND", "DETAIL": "no"}},
+            )
+        mock_aio.get(
+            tv_url("SERIAL_NUMBER"),
+            payload={
+                "STATUS": {"RESULT": "SUCCESS", "DETAIL": "Success"},
+                "ITEMS": [{"CNAME": "serial_number", "VALUE": "FALLBACK-SN-1"}],
+            },
+        )
+        assert await vizio_tv.get_serial_number() == "FALLBACK-SN-1"
+
+    async def test_aggregate_uri_not_found_caches_negative_result(
+        self, vizio_tv, mock_aio
+    ) -> None:
+        """After both aggregate paths return URI_NOT_FOUND, subsequent
+        identity calls must NOT re-probe the aggregate. With only the
+        per-field URLs mocked, a second call would error if the cache
+        weren't honored."""
+        for endpoint in ("TV_INFORMATION", "_ALT_TV_INFORMATION"):
+            mock_aio.get(
+                tv_url(endpoint),
+                payload={"STATUS": {"RESULT": "URI_NOT_FOUND", "DETAIL": "no"}},
+            )
+        mock_aio.get(
+            tv_url("SERIAL_NUMBER"),
+            payload={
+                "STATUS": {"RESULT": "SUCCESS", "DETAIL": "Success"},
+                "ITEMS": [{"CNAME": "serial_number", "VALUE": "SN-1"}],
+            },
+        )
+        mock_aio.get(
+            tv_url("VERSION"),
+            payload={
+                "STATUS": {"RESULT": "SUCCESS", "DETAIL": "Success"},
+                "ITEMS": [{"CNAME": "version", "VALUE": "1.2.3"}],
+            },
+        )
+        assert await vizio_tv.get_serial_number() == "SN-1"
+        # Second call: only per-field VERSION is mocked. If cache wasn't
+        # honored, this would re-hit TV_INFORMATION, but aioresponses
+        # would consume both URI_NOT_FOUND mocks on the first call.
+        assert await vizio_tv.get_version() == "1.2.3"
+
+    async def test_identity_cache_is_per_instance(self, mock_aio) -> None:
+        """Two VizioAsync instances must not share an identity cache —
+        identity is per-device, not per-class. Catches the bug class
+        where ``_cached_identity`` accidentally lives on the class
+        rather than ``self``."""
+        v1 = VizioAsync(
+            device_id="t1",
+            ip="192.168.1.10:7345",
+            name="T1",
+            auth_token=AUTH_TOKEN,
+            device_type="tv",
+        )
+        v2 = VizioAsync(
+            device_id="t2",
+            ip="192.168.1.20:7345",
+            name="T2",
+            auth_token=AUTH_TOKEN,
+            device_type="tv",
+        )
+        mock_aio.get(
+            "https://192.168.1.10:7345/menu_native/dynamic/tv_settings/admin_and_privacy/system_information/tv_information",
+            payload={
+                "STATUS": {"RESULT": "SUCCESS"},
+                "ITEMS": [{"CNAME": "serial_number", "VALUE": "SN-FROM-V1"}],
+            },
+        )
+        mock_aio.get(
+            "https://192.168.1.20:7345/menu_native/dynamic/tv_settings/admin_and_privacy/system_information/tv_information",
+            payload={
+                "STATUS": {"RESULT": "SUCCESS"},
+                "ITEMS": [{"CNAME": "serial_number", "VALUE": "SN-FROM-V2"}],
+            },
+        )
+        assert await v1.get_serial_number() == "SN-FROM-V1"
+        assert await v2.get_serial_number() == "SN-FROM-V2"
+
+    async def test_aggregate_transient_failure_does_not_poison_cache(
+        self, vizio_tv, mock_aio
+    ) -> None:
+        """A transient HTTP 500 on the aggregate must NOT cache None.
+        The next identity call should retry the aggregate (and ideally
+        succeed). Without the propagate_errors fix, a single transient
+        blip would permanently disable the optimization."""
+        # First aggregate call: transport error.
+        mock_aio.get(tv_url("TV_INFORMATION"), status=500)
+        mock_aio.get(tv_url("_ALT_TV_INFORMATION"), status=500)
+        # Per-field fallback succeeds for the first call.
+        mock_aio.get(
+            tv_url("SERIAL_NUMBER"),
+            payload={
+                "STATUS": {"RESULT": "SUCCESS", "DETAIL": "Success"},
+                "ITEMS": [{"CNAME": "serial_number", "VALUE": "FALLBACK-SN"}],
+            },
+        )
+        assert (
+            await vizio_tv.get_serial_number(log_api_exception=False) == "FALLBACK-SN"
+        )
+        # Second aggregate call: now succeeds. Cache wasn't poisoned,
+        # so the aggregate is re-tried and the value comes from there.
+        mock_aio.get(
+            tv_url("TV_INFORMATION"),
+            payload={
+                "STATUS": {"RESULT": "SUCCESS"},
+                "ITEMS": [{"CNAME": "firmware", "VALUE": "9.9.9"}],
+            },
+        )
+        assert await vizio_tv.get_version() == "9.9.9"

--- a/tests/test_state_extended.py
+++ b/tests/test_state_extended.py
@@ -1,0 +1,224 @@
+"""Tests for ``pyvizio.api.state_extended`` and ``Vizio.get_state_extended``.
+
+The ``/state_extended`` endpoint is non-standard — it returns flat
+top-level keys (``POWER_MODE``, ``APP_CURRENT``, …) without the usual
+``STATUS`` / ``ITEMS`` envelope. ``parse_state_extended`` consumes the
+raw payload directly, and ``Vizio.get_state_extended`` invokes the
+underlying transport with ``skip_envelope=True``.
+
+Captured live from a Vizio VHD24M-0810 (firmware 3.720.9.1-1) during
+the hardware-probe pass that motivated this addition.
+"""
+
+from __future__ import annotations
+
+from aioresponses import aioresponses
+import pytest
+
+from pyvizio import VizioAsync
+from pyvizio.api.state_extended import StateExtended, parse_state_extended
+from tests.conftest import AUTH_TOKEN, TV_IP_PORT, tv_url
+
+# ---------------------------------------------------------------------------
+# parse_state_extended (unit, no HTTP)
+# ---------------------------------------------------------------------------
+
+
+class TestParseStateExtended:
+    """Captured payload shapes from real firmware. Parser must produce
+    the expected typed fields and degrade gracefully when fields are
+    missing or have unexpected shapes."""
+
+    def test_full_captured_payload(self) -> None:
+        """Full payload as captured live from VHD24M-0810 fw 3.720.9.1-1
+        on the SmartCast Home screen."""
+        payload = {
+            "ERRORS": [],
+            "URI": "/state_extended",
+            "DEVICE_NAME": "Test TV",
+            "POWER_STATUS": {"VALUE": 1},
+            "POWER_MODE": {"VALUE": "Quick Start", "HASHVAL": 3026334404},
+            "APP_CURRENT": {
+                "APP_ID": "1",
+                "MESSAGE": '{"app":"home","bundle":"bundles/home"}',
+                "NAME_SPACE": 4,
+            },
+            "CURRENT_INPUT": {"NAME": "SMARTCAST", "HASHVAL": 3009117460},
+            "SCREEN_MODE": "Full screen",
+            "MEDIA_STATE": "MediaState::Stopped",
+        }
+        s = parse_state_extended(payload)
+
+        assert isinstance(s, StateExtended)
+        assert s.power_on is True
+        assert s.power_mode == "Quick Start"
+        assert s.current_input == "SMARTCAST"
+        assert s.current_input_hashval == 3009117460
+        assert s.current_app == {
+            "app_id": "1",
+            "name_space": 4,
+            "message": '{"app":"home","bundle":"bundles/home"}',
+        }
+        assert s.screen_mode == "Full screen"
+        assert s.media_state == "MediaState::Stopped"
+        assert s.device_name == "Test TV"
+        assert s.errors == ()
+        assert s.raw == payload
+
+    def test_powered_off(self) -> None:
+        """POWER_STATUS.VALUE = 0 → power_on = False."""
+        payload = {
+            "POWER_STATUS": {"VALUE": 0},
+            "POWER_MODE": {"VALUE": "Active Off"},
+        }
+        s = parse_state_extended(payload)
+        assert s.power_on is False
+        assert s.power_mode == "Active Off"
+
+    def test_minimal_payload_degrades_gracefully(self) -> None:
+        """Older or partial firmware may omit fields — every getter
+        degrades to empty / None / () instead of raising."""
+        s = parse_state_extended({"URI": "/state_extended"})
+        assert s.power_on is False
+        assert s.power_mode == ""
+        assert s.current_input == ""
+        assert s.current_input_hashval is None
+        assert s.current_app is None
+        assert s.screen_mode == ""
+        assert s.media_state == ""
+        assert s.device_name == ""
+        assert s.errors == ()
+
+    def test_missing_app_current_returns_none(self) -> None:
+        """No app running → APP_CURRENT may be missing or empty."""
+        s = parse_state_extended({"POWER_STATUS": {"VALUE": 1}})
+        assert s.current_app is None
+
+    def test_partial_app_current_returns_none(self) -> None:
+        """APP_CURRENT missing app_id or name_space → None (not partial)."""
+        s = parse_state_extended({"APP_CURRENT": {"APP_ID": "5"}})
+        assert s.current_app is None
+
+    def test_app_current_with_invalid_namespace(self) -> None:
+        """Non-integer name_space → None rather than raising."""
+        s = parse_state_extended(
+            {"APP_CURRENT": {"APP_ID": "5", "NAME_SPACE": "not-a-number"}}
+        )
+        assert s.current_app is None
+
+    def test_current_input_invalid_hashval(self) -> None:
+        """Non-integer hashval degrades to None."""
+        s = parse_state_extended(
+            {"CURRENT_INPUT": {"NAME": "HDMI-1", "HASHVAL": "not-a-number"}}
+        )
+        assert s.current_input == "HDMI-1"
+        assert s.current_input_hashval is None
+
+    def test_errors_array(self) -> None:
+        s = parse_state_extended({"ERRORS": ["disk full", 42, None]})
+        assert s.errors == ("disk full", "42", "None")
+
+    def test_errors_non_list_ignored(self) -> None:
+        """Defensive: ERRORS as a non-list shape doesn't crash."""
+        s = parse_state_extended({"ERRORS": "oops"})
+        assert s.errors == ()
+
+    def test_lowercase_keys(self) -> None:
+        """Parser is case-insensitive (devices normalize keys variably)."""
+        s = parse_state_extended(
+            {
+                "power_status": {"value": 1},
+                "current_input": {"name": "HDMI-1", "hashval": 7},
+                "screen_mode": "Full screen",
+            }
+        )
+        assert s.power_on is True
+        assert s.current_input == "HDMI-1"
+        assert s.current_input_hashval == 7
+        assert s.screen_mode == "Full screen"
+
+
+# ---------------------------------------------------------------------------
+# Vizio.get_state_extended (integration, HTTP-mocked)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def vizio_tv() -> VizioAsync:
+    return VizioAsync(
+        device_id="test",
+        ip=TV_IP_PORT,
+        name="TV",
+        auth_token=AUTH_TOKEN,
+        device_type="tv",
+    )
+
+
+@pytest.fixture
+def mock_aio():
+    with aioresponses() as m:
+        yield m
+
+
+class TestVizioGetStateExtended:
+    """End-to-end via HTTP mocking — exercises the non-standard envelope
+    bypass (``skip_envelope=True`` through the invoke chain) and the
+    parser together."""
+
+    async def test_round_trip(self, vizio_tv, mock_aio) -> None:
+        mock_aio.get(
+            tv_url("STATE_EXTENDED"),
+            payload={
+                "POWER_STATUS": {"VALUE": 1},
+                "POWER_MODE": {"VALUE": "On"},
+                "CURRENT_INPUT": {"NAME": "HDMI-1", "HASHVAL": 42},
+                "SCREEN_MODE": "Full screen",
+                "MEDIA_STATE": "MediaState::Stopped",
+                "DEVICE_NAME": "Test TV",
+            },
+        )
+        s = await vizio_tv.get_state_extended()
+        assert s is not None
+        assert s.power_on is True
+        assert s.current_input == "HDMI-1"
+        assert s.device_name == "Test TV"
+
+    async def test_uri_not_found_envelope_returns_none(
+        self, vizio_tv, mock_aio
+    ) -> None:
+        """Older firmware that doesn't expose ``/state_extended`` returns
+        the standard SCPL envelope ``{"STATUS": {"RESULT":
+        "URI_NOT_FOUND", ...}}`` rather than the flat-keyed shape we
+        want. ``skip_envelope=True`` deliberately bypasses validation
+        (the success-case payload doesn't have STATUS/ITEMS), so
+        ``get_state_extended`` detects an envelope-shaped error
+        manually and returns ``None``. Without this check, the parser
+        would happily produce a default-filled ``StateExtended`` and
+        callers couldn't distinguish "endpoint unsupported" from
+        "real all-default state."""
+        mock_aio.get(
+            tv_url("STATE_EXTENDED"),
+            payload={"STATUS": {"RESULT": "URI_NOT_FOUND", "DETAIL": "URI not found"}},
+        )
+        assert await vizio_tv.get_state_extended(log_api_exception=False) is None
+
+    async def test_unsupported_device_class(self) -> None:
+        """Speakers and Crave don't define STATE_EXTENDED; library must
+        gate before any HTTP work rather than crashing with a KeyError
+        from the missing endpoint lookup. Returns ``None`` (the
+        documented "not available" signal)."""
+        speaker = VizioAsync(
+            device_id="probe",
+            ip="192.168.1.50:9000",
+            name="Speaker",
+            auth_token="",
+            device_type="speaker",
+        )
+        # No HTTP mock needed — the endpoint-presence gate
+        # short-circuits before any request would fire.
+        assert await speaker.get_state_extended(log_api_exception=False) is None
+
+    async def test_http_error_returns_none(self, vizio_tv, mock_aio) -> None:
+        """Connection failure with log_api_exception=False returns None."""
+        mock_aio.get(tv_url("STATE_EXTENDED"), status=500)
+        assert await vizio_tv.get_state_extended(log_api_exception=False) is None

--- a/tests/test_state_extended.py
+++ b/tests/test_state_extended.py
@@ -75,6 +75,26 @@ class TestParseStateExtended:
         assert s.power_on is False
         assert s.power_mode == "Active Off"
 
+    @pytest.mark.parametrize(
+        "raw_value,expected",
+        [
+            (1, True),
+            (0, False),
+            ("1", True),
+            ("0", False),  # Critical: bool("0") is True; we use int().
+            ("anything-else", False),
+            (None, False),
+        ],
+    )
+    def test_power_on_coercion(self, raw_value, expected) -> None:
+        """``POWER_STATUS.VALUE`` is coerced via ``int()`` rather than
+        ``bool()``. Firmware has been observed to serialize the value
+        as either int or string; ``bool("0")`` is truthy and would
+        incorrectly report powered-on, so the parser uses
+        ``int(...) == 1`` with a guarded fallback."""
+        s = parse_state_extended({"POWER_STATUS": {"VALUE": raw_value}})
+        assert s.power_on is expected
+
     def test_minimal_payload_degrades_gracefully(self) -> None:
         """Older or partial firmware may omit fields — every getter
         degrades to empty / None / () instead of raising."""

--- a/tests/test_state_extended.py
+++ b/tests/test_state_extended.py
@@ -202,11 +202,13 @@ class TestVizioGetStateExtended:
         )
         assert await vizio_tv.get_state_extended(log_api_exception=False) is None
 
-    async def test_unsupported_device_class(self) -> None:
-        """Speakers and Crave don't define STATE_EXTENDED; library must
-        gate before any HTTP work rather than crashing with a KeyError
-        from the missing endpoint lookup. Returns ``None`` (the
-        documented "not available" signal)."""
+    async def test_unsupported_device_class_raises(self) -> None:
+        """Speakers and Crave don't define STATE_EXTENDED; the library
+        gates before any HTTP work and raises VizioUnsupportedError
+        (a programming-level invariant, not a runtime device error,
+        so it always raises rather than swallowing into None)."""
+        from pyvizio import VizioUnsupportedError
+
         speaker = VizioAsync(
             device_id="probe",
             ip="192.168.1.50:9000",
@@ -216,9 +218,66 @@ class TestVizioGetStateExtended:
         )
         # No HTTP mock needed — the endpoint-presence gate
         # short-circuits before any request would fire.
-        assert await speaker.get_state_extended(log_api_exception=False) is None
+        with pytest.raises(VizioUnsupportedError, match="doesn't expose"):
+            await speaker.get_state_extended(log_api_exception=False)
+        with pytest.raises(VizioUnsupportedError):
+            await speaker.get_state_extended()
 
     async def test_http_error_returns_none(self, vizio_tv, mock_aio) -> None:
         """Connection failure with log_api_exception=False returns None."""
         mock_aio.get(tv_url("STATE_EXTENDED"), status=500)
         assert await vizio_tv.get_state_extended(log_api_exception=False) is None
+
+    async def test_http_403_propagates_auth_error(self, vizio_tv, mock_aio) -> None:
+        """HTTP 403 must propagate as VizioAuthError even with
+        log_api_exception=False — the try/except VizioAuthError: raise
+        ordering is load-bearing. A refactor that drops it would let
+        re-pair invalidation silently produce None on /state_extended."""
+        from pyvizio import VizioAuthError
+
+        mock_aio.get(tv_url("STATE_EXTENDED"), status=403)
+        with pytest.raises(VizioAuthError):
+            await vizio_tv.get_state_extended(log_api_exception=False)
+
+    async def test_minimal_payload_round_trip(self, vizio_tv, mock_aio) -> None:
+        """End-to-end coverage that the parser's degradation behavior
+        survives the HTTP path — only POWER_STATUS in the response."""
+        mock_aio.get(
+            tv_url("STATE_EXTENDED"),
+            payload={"POWER_STATUS": {"VALUE": 1}},
+        )
+        s = await vizio_tv.get_state_extended()
+        assert s is not None
+        assert s.power_on is True
+        assert s.current_input == ""
+        assert s.current_app is None
+
+    async def test_blocked_envelope_returns_none_without_caching(
+        self, vizio_tv, mock_aio
+    ) -> None:
+        """A BLOCKED envelope is transient — must not cache as
+        unavailable. A second call should re-probe and succeed."""
+        mock_aio.get(
+            tv_url("STATE_EXTENDED"),
+            payload={"STATUS": {"RESULT": "BLOCKED", "DETAIL": "busy"}},
+        )
+        assert await vizio_tv.get_state_extended(log_api_exception=False) is None
+
+        mock_aio.get(
+            tv_url("STATE_EXTENDED"),
+            payload={"POWER_STATUS": {"VALUE": 1}, "DEVICE_NAME": "TV"},
+        )
+        s = await vizio_tv.get_state_extended()
+        assert s is not None and s.device_name == "TV"
+
+    async def test_uri_not_found_caches_unavailable(self, vizio_tv, mock_aio) -> None:
+        """A URI_NOT_FOUND envelope is definitive — cache it so polling
+        integrations don't re-pay every cycle. Second call returns None
+        without an HTTP mock (aioresponses raises if it fires)."""
+        mock_aio.get(
+            tv_url("STATE_EXTENDED"),
+            payload={"STATUS": {"RESULT": "URI_NOT_FOUND", "DETAIL": "no"}},
+        )
+        assert await vizio_tv.get_state_extended() is None
+        # No new mock — second call must not hit the network.
+        assert await vizio_tv.get_state_extended() is None

--- a/tests/test_sync_api.py
+++ b/tests/test_sync_api.py
@@ -12,6 +12,7 @@ from tests.conftest import (
     TV_IP_PORT,
     make_app_response,
     make_current_input_response,
+    make_inputs_list_response,
     make_item,
     make_key_press_response,
     make_power_response,
@@ -88,6 +89,15 @@ class TestSyncInput:
             m.get(
                 tv_url("CURRENT_INPUT"),
                 payload=make_current_input_response("current_input", "HDMI-1", 5),
+            )
+            m.get(
+                tv_url("INPUTS"),
+                payload=make_inputs_list_response(
+                    [
+                        ("hdmi1", "HDMI-1", "Living Room", 1),
+                        ("hdmi2", "HDMI-2", "Console", 2),
+                    ]
+                ),
             )
             m.put(tv_url("CURRENT_INPUT"), payload=make_response())
             result = vizio_sync.set_input("HDMI-2")


### PR DESCRIPTION
## Summary

Live-verified protocol fixes from a hardware-probe pass against a Vizio VHD24M-0810 (firmware 3.720.9.1-1), ported onto master's command-pattern architecture. Closes #135, closes #140.

- **Bug fixes:** ``set_input`` cname translation, HTTP 401/403 → ``VizioAuthError`` (with always-propagate semantics), aggregate ``tv_information`` identity endpoint with per-instance caching, ``get_version`` accepts ``firmware`` cname alias, state-aware ``mute_on``/``mute_off``, ``can_connect_with_auth_check`` preserves bool contract.
- **New endpoint:** ``Vizio.get_state_extended()`` for bulk single-round-trip polling (power, current input, current app, screen mode, media state).
- **New typed exceptions:** ``VizioBusyError``, ``VizioNotFoundError``, ``VizioInvalidInputError``, ``VizioUnsupportedError``, ``VizioHashvalError``.
- **New keymap entries:** ``NUM_0``..``NUM_9`` on the TV keymap.
- **284 tests pass** (was 223 on master); two new test files plus updates to existing.

## Why this PR vs PR #197

PR #197 carried the same fixes on top of the v2-redesign rewrite (~2000 lines net). With the upstream HA integration moving to a different package, the v2 redesign is no longer worth the churn — this PR carries only the bug fixes and new features onto master, narrowly scoped to the modules that actually need changes.

## Bug fixes

### ``set_input`` cname translation
Modern firmware requires the lowercase **cname** (``"hdmi2"``) in the PUT body. Live-verified: display name (``"HDMI-2"``) returns ``RESULT: FAILURE``, meta_name (``"Mac"``, ``"SMARTCAST"``) returns ``RESULT: HASHVAL_ERROR``, only the lowercase cname returns ``SUCCESS``. The library now resolves any of cname / display name / meta_name (case-insensitive, ambiguity-checked per tier) to the canonical cname before sending. Short-circuits when target == current — the device explicitly rejects "switch to current input" with FAILURE. Issues two GETs unconditionally (current input + inputs list) before the conditional PUT.

### HTTP 401/403 → ``VizioAuthError``
Live-verified: re-pairing with the same ``device_id`` immediately invalidates the previous token, and subsequent calls with the old token return raw HTTP 403 (not the ``PAIRING_DENIED`` envelope). HTTP 401/403 now map to ``VizioAuthError`` in ``async_validate_response``. Auth errors **always propagate** through ``async_invoke_api`` regardless of ``log_api_exception``, so probe-style helpers can detect re-pair invalidation. ``can_connect_with_auth_check`` catches it locally to preserve its bool contract.

### Identity-aggregate endpoint with per-instance cache
Modern firmware exposes ``serial_number``, ``firmware``, ``model_name``, etc. under a single ``tv_information`` parent and rejects per-field children with ``URI_NOT_FOUND``. ``get_serial_number`` / ``get_version`` (and ``get_esn`` for auth-bearing callers) now prefer the aggregate, falling back to per-field on URI_NOT_FOUND. Three identity calls collapse to one HTTP round trip on modern firmware. Cache rules:
- ``URI_NOT_FOUND`` on every candidate path → cache ``None`` (firmware definitively doesn't expose; stop probing).
- Transient failure (transport, busy, malformed) → **don't** cache; next call retries.
- Probe-style + auth-required (e.g. ``get_unique_id`` with empty token on a TV) → skip the aggregate entirely (let per-field fallback take over).

ESN is **not** carried in the aggregate (lives under ``uli_information/``, not ``tv_information/``); ``get_esn`` always falls through to its per-field path.

### ``get_version`` accepts ``firmware`` cname alias
Modern firmware exposes the version under cname ``"firmware"``; legacy uses ``"version"``. Both are handled.

### State-aware ``mute_on`` / ``mute_off``
Live-verified: discrete ``MUTE_ON`` / ``MUTE_OFF`` codes don't actually exist as discrete actions on this firmware — codeset 5 codes 2/3/4 all behave as toggles. The library now reads current mute state via ``is_muted()`` and sends ``MUTE_TOGGLE`` only on mismatch. When the state probe fails (transport / device error → ``is_muted`` returns ``None``), ``mute_on``/``mute_off`` early-return ``None`` rather than blindly toggling on an unknown state. Power users can still send raw codes via ``remote("MUTE_ON")``.

### Robust transport error handling
``_do_request`` wraps raw transport exceptions (``aiohttp.ClientError``, ``asyncio.TimeoutError``, ``OSError``, ``ssl.SSLError``) into ``VizioConnectionError`` so callers using the new ``propagate_errors=True`` path see typed exceptions instead of having transport failures fall through the broad ``except Exception`` and silently become ``None`` (which would otherwise poison the identity cache on a single TCP blip).

## New envelope-status mappings (``async_validate_response``)

| Envelope status | Mapped exception |
|---|---|
| ``URI_NOT_FOUND`` | ``VizioNotFoundError`` |
| ``HASHVAL_ERROR`` | ``VizioHashvalError`` (subclass of ``VizioInvalidParameterError``) |
| ``BLOCKED`` | ``VizioBusyError`` |
| ``REQUIRES_PAIRING`` / ``PAIRING_DENIED`` | ``VizioAuthError`` |
| HTTP 401 / 403 | ``VizioAuthError`` |

Parse-failure exception now includes a 200-char body snippet (was the unrenderable ``<StreamReader>`` object).

## New: ``/state_extended`` endpoint

``Vizio.get_state_extended()`` — bulk single-round-trip poll returning power, current input, current app, screen mode, and media state. Capability advertised under ``deviceinfo.scpl_capabilities.state_extended``.

The success-case payload uses a non-standard envelope (flat top-level keys, no ``STATUS``/``ITEMS``); ``async_invoke_api`` gains a ``skip_envelope=True`` flag for this case. Older firmware that doesn't expose the endpoint returns the standard SCPL envelope with ``RESULT: URI_NOT_FOUND``; this method detects that shape on the raw payload and returns ``None`` (the URI_NOT_FOUND result is also cached on the instance so HA-style polling doesn't re-pay every cycle). Other envelope statuses (``BLOCKED``, ``REQUIRES_PAIRING``, unrecognized) are dispatched correctly: auth-class envelopes raise, transient errors return ``None`` without caching.

Gated to TV via the ``STATE_EXTENDED`` endpoint key (not present in DEVICE_CONFIGS for speakers / Crave); calling on those device classes raises ``VizioUnsupportedError`` (a programming-level invariant, always propagates).

## New types

| Type | Purpose |
|---|---|
| ``StateExtended`` | Frozen dataclass, typed view of ``/state_extended``. ``current_app`` is a ``CurrentApp`` ``TypedDict``. |
| ``VizioBusyError`` | Envelope ``BLOCKED`` |
| ``VizioNotFoundError`` | Envelope ``URI_NOT_FOUND`` (HTTP 200 + status, not HTTP 404) |
| ``VizioInvalidInputError(VizioInvalidParameterError)`` | Raised by the input cname resolver |
| ``VizioUnsupportedError`` | Device-class capability mismatch — always raises |
| ``VizioHashvalError(VizioInvalidParameterError)`` | Stale-hashval write — catch this for refetch+retry; parent still catches |

All new types are re-exported from the top-level ``pyvizio`` package.

## Other additions

- ``NUM_0``..``NUM_9`` keys added to TV keymap (codeset 0, codes 0-9). Tuner-equipped models use these for direct channel entry; tuner-less models reject them with FAILURE per-key, which surfaces as a normal command failure rather than a Python ``KeyError``.

## Test plan

- [x] ``uv run pytest tests/`` — 284 passed (was 223 on master)
- [x] ``uv run ruff check pyvizio/ tests/`` — clean
- [x] ``uv run ruff format --check pyvizio/ tests/`` — clean
- [x] Pre-commit hooks (ruff, ruff-format, mypy, build wheel) — all pass
- [x] Two rounds of code review applied (Copilot + 5 specialized agents per round); 21 + 12 findings addressed
- [ ] Live-verify against the VHD24M-0810: identity aggregate, set_input across all four identifier forms, /state_extended, state-aware mute, HTTP 403 → auth error mapping

## New test coverage

- ``tests/test_real_device_fixes.py`` (30 tests): cname resolver tiers and ambiguity (cname / meta_name / display_name), envelope status mapping (parametrized over all five new statuses with ``HashvalError`` checked against both itself and ``InvalidParameterError`` parent), HTTP status mapping (401/403/500), ``VizioAuthError`` propagation through ``async_invoke_api``, ``can_connect_with_auth_check`` bool contract under HTTP 403, identity aggregate (success, firmware-cname alias, per-instance caching, fallback to per-field on URI_NOT_FOUND, negative-cache after URI_NOT_FOUND, transient HTTP 500 doesn't poison cache, transport-level ``asyncio.TimeoutError`` doesn't poison cache, probe-style aggregate skip).

- ``tests/test_state_extended.py`` (24 tests): ``parse_state_extended`` unit tests — full captured payload, every degradation path, lowercase keys, parametrized ``power_on`` coercion across int/str/None inputs to lock in ``int(...) == 1`` over ``bool(...)``. Plus integration: HTTP-mocked round trip, URI_NOT_FOUND envelope detection, BLOCKED transient (no cache), URI_NOT_FOUND caching, HTTP 403 propagation, minimal-payload integration round trip, speaker-gate raises ``VizioUnsupportedError``.

- ``tests/test_async_api.py`` / ``tests/test_sync_api.py``: ``set_input`` updated for cname-resolution mocking; new ``set_input`` short-circuit tests parametrized over HDMI display name / cname / meta_name / CAST forms (with no PUT mock, so ``aioresponses`` raises if the short-circuit fails); ``set_input`` PUT-failure-after-resolution returns ``None``; mute tests split into ``mute_toggle`` (unchanged), state-aware ``mute_on``/``mute_off`` parametrized over (current state × needs-toggle), probe-failure-returns-``None``, and KEY_PRESS-PUT-failure-returns-``False``.

🤖 Generated with [Claude Code](https://claude.com/claude-code)